### PR TITLE
feat: only accept multiple url-encoded values when expecting a slice

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -774,7 +774,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 			err:         api.ErrInvalidParam,
 		},
 		{
-			name: "invalid query multi param",
+			name: "query unexpected slice param",
 			manifest: `[
 				{
 					"method": "GET",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -930,6 +930,16 @@ func TestMatchSimple(t *testing.T) {
 		{
 			`[ {
 					"method": "GET",
+					"path": "/a",
+					"info": "info",
+					"in": {}
+			} ]`,
+			"/a?param=value",
+			true,
+		},
+		{
+			`[ {
+					"method": "GET",
 					"path": "/a/{id}",
 					"info": "info",
 					"in": {

--- a/internal/reqdata/set.go
+++ b/internal/reqdata/set.go
@@ -77,11 +77,17 @@ func (i *T) GetQuery(req http.Request) error {
 
 		var parsed interface{}
 
-		// consider element instead of slice or elements when only 1
-		if len(values) == 1 {
-			parsed = parseParameter(values[0])
-		} else { // consider slice
+		// consider slice only if we expect a slice, otherwise, only take the first parameter
+		if param.GoType.Kind() == reflect.Slice {
 			parsed = parseParameter(values)
+		} else {
+			// should expect at most 1 value
+			if len(values) > 1 {
+				return fmt.Errorf("%s: %w", name, ErrInvalidType)
+			}
+			if len(values) > 0 {
+				parsed = parseParameter(values[0])
+			}
 		}
 
 		cast, valid := param.Validator(parsed)
@@ -181,11 +187,17 @@ func (i *T) parseUrlencoded(req http.Request) error {
 
 		var parsed interface{}
 
-		// consider element instead of slice or elements when only 1
-		if len(values) == 1 {
-			parsed = parseParameter(values[0])
-		} else { // consider slice
+		// consider slice only if we expect a slice, otherwise, only take the first parameter
+		if param.GoType.Kind() == reflect.Slice {
 			parsed = parseParameter(values)
+		} else if len(values) > 0 {
+			// should expect at most 1 value
+			if len(values) > 1 {
+				return fmt.Errorf("%s: %w", name, ErrInvalidType)
+			}
+			if len(values) > 0 {
+				parsed = parseParameter(values[0])
+			}
 		}
 
 		cast, valid := param.Validator(parsed)


### PR DESCRIPTION
If the `validator.Type` expects a slice-type we accept any number of values and we validate as such.
Otherwise we consider an empty slice as a null value, a 1-sized slice as the value to validate and bigger slices throw an invalid type error.