### PR TITLE
fix: multipar file upload

### DIFF
--- a/internal/multipart/reader.go
+++ b/internal/multipart/reader.go
@@ -6,6 +6,9 @@ import (
 	"io"
 )
 
+// DefaultContentType used when a component is NOT a file but literal data
+const DefaultContentType = "raw"
+
 // Reader is a multipart reader.
 type Reader struct {
 	// io.Reader used for reading multipart components reading.

--- a/internal/reqdata/parse_parameter_test.go
+++ b/internal/reqdata/parse_parameter_test.go
@@ -227,9 +227,9 @@ func TestJsonBoolSlice(t *testing.T) {
 func TestBoolSlice(t *testing.T) {
 	p := parseParameter([]bool{true, false})
 
-	slice, canCast := p.([]interface{})
+	slice, canCast := p.([]bool)
 	if !canCast {
-		t.Errorf("expected parameter to be a []interface{}")
+		t.Errorf("expected parameter to be a []bool")
 		t.FailNow()
 	}
 
@@ -241,12 +241,7 @@ func TestBoolSlice(t *testing.T) {
 	results := []bool{true, false}
 
 	for i, res := range results {
-
-		cast, canCast := slice[i].(bool)
-		if !canCast {
-			t.Errorf("expected parameter %d to be a bool, got %v", i, slice[i])
-			continue
-		}
+		cast := slice[i]
 		if cast != res {
 			t.Errorf("expected first value to be '%t', got '%t'", res, cast)
 			continue

--- a/internal/reqdata/set.go
+++ b/internal/reqdata/set.go
@@ -234,7 +234,7 @@ func (i *T) parseMultipart(req http.Request) error {
 			continue
 		}
 
-		parsed := parseParameter(string(component.Data))
+		parsed := parseParameter(component.Data)
 		cast, valid := param.Validator(parsed)
 		if !valid {
 			return &Err{field: param.Rename, err: ErrInvalidType}


### PR DESCRIPTION
**Observations**
Multipart file uploads are breaking binary data.

It was caused to a cast from `[]byte` to `string`.


**Solution**

We only cast to `string` when a parameter is not a file (_i.e. it has no Content-Type header_). Also when parsing parameters, bypass byte arrays.