### PR TITLE
feature: improve the builder api and coverage

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -89,11 +89,12 @@ func (b *Builder) Output(name string, goType reflect.Type) error {
 
 // RespondWith defines the server responder, i.e. how to write data and error
 // into the http response.
-func (b *Builder) RespondWith(responder Responder) {
+func (b *Builder) RespondWith(responder Responder) error {
 	if responder == nil {
-		return
+		return errNilResponder
 	}
 	b.respond = responder
+	return nil
 }
 
 // With adds an http middleware on top of the http connection

--- a/builder.go
+++ b/builder.go
@@ -75,15 +75,19 @@ func (b *Builder) Input(t validator.Type) error {
 	return nil
 }
 
-// Output adds an go type to use for output arguments
-func (b *Builder) Output(name string, goType reflect.Type) error {
+// Output adds an type available for output arguments as well as a value example.
+// Some examples:
+// - Output("uint",  uint(0))
+// - Output("user",  model.User{})
+// - Output("users", []model.User{})
+func (b *Builder) Output(name string, sample interface{}) error {
 	if b.conf == nil {
 		b.conf = &config.Server{}
 	}
 	if b.conf.Services != nil {
 		return errLateType
 	}
-	b.conf.AddOutputValidator(name, goType)
+	b.conf.AddOutputValidator(name, reflect.TypeOf(sample))
 	return nil
 }
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -78,6 +78,25 @@ func TestAddOutputType(t *testing.T) {
 	}
 }
 
+func TestNilResponder(t *testing.T) {
+	t.Parallel()
+
+	builder := &Builder{}
+	err := builder.RespondWith(nil)
+	if !errors.Is(err, errNilResponder) {
+		t.Fatalf("expected %q, got %v", errNilResponder.Error(), err)
+	}
+}
+func TestNonNilResponder(t *testing.T) {
+	t.Parallel()
+
+	builder := &Builder{}
+	err := builder.RespondWith(DefaultResponder)
+	if !errors.Is(err, nil) {
+		t.Fatalf("unexpected error %s", err)
+	}
+}
+
 func TestSetupNoType(t *testing.T) {
 	t.Parallel()
 
@@ -87,6 +106,7 @@ func TestSetupNoType(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
+
 func TestSetupTwice(t *testing.T) {
 	t.Parallel()
 
@@ -126,6 +146,7 @@ func TestBindUnknownService(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", errUnknownService, err)
 	}
 }
+
 func TestBindInvalidHandler(t *testing.T) {
 	t.Parallel()
 
@@ -153,7 +174,8 @@ func TestBindInvalidHandler(t *testing.T) {
 		t.Fatalf("expected a dynfunc.Err got %v", err)
 	}
 }
-func TestBindGet(t *testing.T) {
+
+func TestBindMethods(t *testing.T) {
 	t.Parallel()
 
 	builder := &Builder{}

--- a/builder_test.go
+++ b/builder_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -21,13 +20,13 @@ func addBuiltinTypes(b *Builder) error {
 		validator.StringType{},
 		validator.UintType{},
 	}
-	outputTypes := map[string]reflect.Type{
-		"any":    reflect.TypeOf(interface{}(nil)),
-		"bool":   reflect.TypeOf(true),
-		"float":  reflect.TypeOf(float64(2)),
-		"int":    reflect.TypeOf(int(0)),
-		"string": reflect.TypeOf(""),
-		"uint":   reflect.TypeOf(uint(0)),
+	outputTypes := map[string]interface{}{
+		"any":    interface{}(nil),
+		"bool":   true,
+		"float":  float64(2),
+		"int":    int(0),
+		"string": "",
+		"uint":   uint(0),
 	}
 
 	for _, t := range inputTypes {
@@ -64,7 +63,7 @@ func TestAddOutputType(t *testing.T) {
 	t.Parallel()
 
 	builder := &Builder{}
-	err := builder.Output("bool", reflect.TypeOf(true))
+	err := builder.Output("bool", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -72,7 +71,7 @@ func TestAddOutputType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	err = builder.Output("bool", reflect.TypeOf(true))
+	err = builder.Output("bool", true)
 	if err != errLateType {
 		t.Fatalf("expected <%v> got <%v>", errLateType, err)
 	}

--- a/errors.go
+++ b/errors.go
@@ -22,4 +22,7 @@ const (
 
 	// errMissingHandler - missing handler
 	errMissingHandler = cerr("missing handler")
+
+	// errNilResponder - nil responder provided
+	errNilResponder = cerr("nil responder")
 )

--- a/handler_test.go
+++ b/handler_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -31,13 +30,13 @@ func addDefaultTypes(b *aicra.Builder) error {
 		validator.StringType{},
 		validator.UintType{},
 	}
-	outputTypes := map[string]reflect.Type{
-		"any":    reflect.TypeOf(interface{}(nil)),
-		"bool":   reflect.TypeOf(true),
-		"float":  reflect.TypeOf(float64(2)),
-		"int":    reflect.TypeOf(int(0)),
-		"string": reflect.TypeOf(""),
-		"uint":   reflect.TypeOf(uint(0)),
+	outputTypes := map[string]interface{}{
+		"any":    interface{}(nil),
+		"bool":   true,
+		"float":  float64(2),
+		"int":    int(0),
+		"string": "",
+		"uint":   uint(0),
 	}
 
 	for _, t := range inputTypes {

--- a/handler_test.go
+++ b/handler_test.go
@@ -52,7 +52,7 @@ func addDefaultTypes(b *aicra.Builder) error {
 	return nil
 }
 
-func TestHandler_With(t *testing.T) {
+func TestHandlerWith(t *testing.T) {
 	builder := &aicra.Builder{}
 	if err := addDefaultTypes(builder); err != nil {
 		t.Fatalf("unexpected error <%v>", err)
@@ -136,83 +136,83 @@ func TestHandler_With(t *testing.T) {
 
 }
 
-func TestHandler_WithAuth(t *testing.T) {
+func TestHandlerWithAuth(t *testing.T) {
 
 	tt := []struct {
 		name        string
-		manifest    string
+		config      string
 		permissions []string
 		granted     bool
 	}{
 		{
 			name:        "provide only requirement A",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A"},
 			granted:     true,
 		},
 		{
 			name:        "missing requirement",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{},
 			granted:     false,
 		},
 		{
 			name:        "missing requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{},
 			granted:     false,
 		},
 		{
 			name:        "missing some requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A"},
 			granted:     false,
 		},
 		{
 			name:        "provide requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A", "B"},
 			granted:     true,
 		},
 		{
 			name:        "missing OR requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"], ["B"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"], ["B"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"C"},
 			granted:     false,
 		},
 		{
 			name:        "provide 1 OR requirement",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"], ["B"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"], ["B"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A"},
 			granted:     true,
 		},
 		{
 			name:        "provide both OR requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"], ["B"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"], ["B"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A", "B"},
 			granted:     true,
 		},
 		{
 			name:        "missing composite OR requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{},
 			granted:     false,
 		},
 		{
 			name:        "missing partial composite OR requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A", "C"},
 			granted:     false,
 		},
 		{
 			name:        "provide 1 composite OR requirement",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A", "B", "C"},
 			granted:     true,
 		},
 		{
 			name:        "provide both composite OR requirements",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A", "B"], ["C", "D"]], "info": "info", "in": {}, "out": {} } ]`,
 			permissions: []string{"A", "B", "C", "D"},
 			granted:     true,
 		},
@@ -257,7 +257,7 @@ func TestHandler_WithAuth(t *testing.T) {
 				})
 			})
 
-			err := builder.Setup(strings.NewReader(tc.manifest))
+			err := builder.Setup(strings.NewReader(tc.config))
 			if err != nil {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
@@ -289,12 +289,12 @@ func TestHandler_WithAuth(t *testing.T) {
 
 }
 
-func TestHandler_PermissionError(t *testing.T) {
+func TestHandlerPermissionError(t *testing.T) {
 	tt := []struct {
 		name        string
 		path        string
 		uri, body   string
-		manifest    string
+		config      string
 		handler     interface{}
 		permissions []string
 		err         api.Err
@@ -303,7 +303,7 @@ func TestHandler_PermissionError(t *testing.T) {
 			name:        "permission fulfilled",
 			path:        "/path",
 			uri:         "/path",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
 			handler:     func(ctx context.Context) (*struct{}, error) { return nil, api.ErrNotImplemented },
 			permissions: []string{"A"},
 			err:         api.ErrNotImplemented,
@@ -312,7 +312,7 @@ func TestHandler_PermissionError(t *testing.T) {
 			name:        "missing permission",
 			path:        "/path",
 			uri:         "/path",
-			manifest:    `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
+			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
 			handler:     func(ctx context.Context) (*struct{}, error) { return nil, api.ErrNotImplemented },
 			permissions: []string{},
 			err:         api.ErrForbidden,
@@ -324,7 +324,7 @@ func TestHandler_PermissionError(t *testing.T) {
 			name: "permission with wrong uri param",
 			path: "/path/{uid}",
 			uri:  "/path/abc",
-			manifest: `[ {
+			config: `[ {
 				"method": "GET",
 				"path": "/path/{uid}",
 				"scope": [["missing"]],
@@ -344,7 +344,7 @@ func TestHandler_PermissionError(t *testing.T) {
 			name: "permission with wrong query param",
 			path: "/path",
 			uri:  "/path?uid=invalid-type",
-			manifest: `[ {
+			config: `[ {
 				"method": "GET",
 				"path": "/path",
 				"scope": [["missing"]],
@@ -365,7 +365,7 @@ func TestHandler_PermissionError(t *testing.T) {
 			path: "/path",
 			uri:  "/path",
 			body: "uid=invalid-type",
-			manifest: `[ {
+			config: `[ {
 				"method": "GET",
 				"path": "/path",
 				"scope": [["missing"]],
@@ -403,7 +403,7 @@ func TestHandler_PermissionError(t *testing.T) {
 				})
 			})
 
-			err := builder.Setup(strings.NewReader(tc.manifest))
+			err := builder.Setup(strings.NewReader(tc.config))
 			if err != nil {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
@@ -439,10 +439,10 @@ func TestHandler_PermissionError(t *testing.T) {
 
 }
 
-func TestHandler_DynamicScope(t *testing.T) {
+func TestHandlerDynamicScope(t *testing.T) {
 	tt := []struct {
 		name        string
-		manifest    string
+		config      string
 		path        string
 		handler     interface{}
 		url         string
@@ -452,7 +452,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 	}{
 		{
 			name: "replace one granted",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/path/{id}",
@@ -473,7 +473,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 		},
 		{
 			name: "replace one mismatch",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/path/{id}",
@@ -494,7 +494,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 		},
 		{
 			name: "replace one valid dot separated",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/path/{id}",
@@ -515,7 +515,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 		},
 		{
 			name: "replace two valid dot separated",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/prefix/{pid}/user/{uid}",
@@ -542,7 +542,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 		},
 		{
 			name: "replace two invalid dot separated",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/prefix/{pid}/user/{uid}",
@@ -569,7 +569,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 		},
 		{
 			name: "replace three valid dot separated",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/prefix/{pid}/user/{uid}/suffix/{sid}",
@@ -598,7 +598,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 		},
 		{
 			name: "replace three invalid dot separated",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/prefix/{pid}/user/{uid}/suffix/{sid}",
@@ -665,7 +665,7 @@ func TestHandler_DynamicScope(t *testing.T) {
 				})
 			})
 
-			err := builder.Setup(strings.NewReader(tc.manifest))
+			err := builder.Setup(strings.NewReader(tc.config))
 			if err != nil {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
@@ -694,10 +694,10 @@ func TestHandler_DynamicScope(t *testing.T) {
 
 }
 
-func TestHandler_ServiceErrors(t *testing.T) {
+func TestHandlerServiceErrors(t *testing.T) {
 	tt := []struct {
-		name     string
-		manifest string
+		name   string
+		config string
 		// handler
 		hmethod, huri string
 		hfn           interface{}
@@ -712,7 +712,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		// service match
 		{
 			name: "unknown service method",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -735,7 +735,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "unknown service path",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -758,7 +758,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "valid empty service",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -783,7 +783,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		// invalid uri param -> unknown service
 		{
 			name: "invalid uri param",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/a/{id}/b",
@@ -810,7 +810,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		// query param
 		{
 			name: "missing query param",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -836,7 +836,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "invalid query param",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/a",
@@ -862,7 +862,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "query unexpected slice param",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/a",
@@ -888,7 +888,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "valid query param",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/a",
@@ -915,7 +915,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		// json param
 		{
 			name: "missing json param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -942,7 +942,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "invalid json param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -969,7 +969,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "valid json param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -997,7 +997,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		// urlencoded param
 		{
 			name: "missing urlencoded param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -1024,7 +1024,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "invalid urlencoded param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -1051,7 +1051,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "valid urlencoded param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -1079,7 +1079,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		// formdata param
 		{
 			name: "missing multipart param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -1106,7 +1106,7 @@ func TestHandler_ServiceErrors(t *testing.T) {
 		},
 		{
 			name: "invalid multipart param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -1137,7 +1137,7 @@ abc
 		},
 		{
 			name: "valid multipart param",
-			manifest: `[
+			config: `[
 				{
 					"method": "POST",
 					"path": "/",
@@ -1174,7 +1174,7 @@ Content-Disposition: form-data; name="id"
 				t.Fatalf("unexpected error <%v>", err)
 			}
 
-			err := builder.Setup(strings.NewReader(tc.manifest))
+			err := builder.Setup(strings.NewReader(tc.config))
 			if err != nil {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
@@ -1227,10 +1227,10 @@ Content-Disposition: form-data; name="id"
 	}
 }
 
-func TestHandler_Response(t *testing.T) {
+func TestHandlerResponse(t *testing.T) {
 	tt := []struct {
-		name     string
-		manifest string
+		name   string
+		config string
 
 		// handler
 		hmethod, huri string
@@ -1242,7 +1242,7 @@ func TestHandler_Response(t *testing.T) {
 	}{
 		{
 			name: "nil error",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -1263,7 +1263,7 @@ func TestHandler_Response(t *testing.T) {
 		},
 		{
 			name: "non-nil error",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -1285,7 +1285,7 @@ func TestHandler_Response(t *testing.T) {
 
 		{
 			name: "nil int output",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -1308,7 +1308,7 @@ func TestHandler_Response(t *testing.T) {
 		},
 		{
 			name: "non-nil int output",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -1331,7 +1331,7 @@ func TestHandler_Response(t *testing.T) {
 		},
 		{
 			name: "nil int outputs",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -1358,7 +1358,7 @@ func TestHandler_Response(t *testing.T) {
 		},
 		{
 			name: "int outputs surrounding error",
-			manifest: `[
+			config: `[
 				{
 					"method": "GET",
 					"path": "/",
@@ -1395,7 +1395,7 @@ func TestHandler_Response(t *testing.T) {
 				t.Fatalf("unexpected error <%v>", err)
 			}
 
-			err := builder.Setup(strings.NewReader(tc.manifest))
+			err := builder.Setup(strings.NewReader(tc.config))
 			if err != nil {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
@@ -1429,7 +1429,7 @@ func TestHandler_Response(t *testing.T) {
 	}
 }
 
-func TestHandler_RequestTooLarge(t *testing.T) {
+func TestHandlerRequestTooLarge(t *testing.T) {
 	tt := []struct {
 		name              string
 		uriMax, uriSize   int

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -12,7 +12,7 @@ import (
 // will be cast into a go type, say, string.
 type ValidateFunc func(value interface{}) (cast interface{}, valid bool)
 
-// Type defines an available in/out parameter "type" for the aicra configuration
+// Type defines an available innput parameter "type" for the aicra configuration
 //
 // A Type maps to a go type in order to generate the handler signature from the
 // aicra configuration
@@ -23,11 +23,11 @@ type Type interface {
 	// typename does not match
 	//
 	// The `typename` argument has to match types used in your aicra configuration
-	// in parameter definitions ("in", "out") and in the "type" json field.
+	// in parameter definitions ("in") and in the "type" json field.
 	//
 	// basic example:
-	// - `IntType.Validator("string")`` should return nil
-	// - `IntType.Validator("int")`` should return its ValidateFunc
+	// - `IntType.Validator("string")` should return nil
+	// - `IntType.Validator("int")` should return its ValidateFunc
 	//
 	// The `typename` is not returned by a simple method i.e. `TypeName() string`
 	// because it allows for validation relative to the typename, for instance:
@@ -42,9 +42,9 @@ type Type interface {
 	//
 	// recursive example: slices
 	// - `SliceType.Validator("[]int", avail...)` validates a slice containing
-	//   values that are valide to the `IntType`
+	//   values that are valid to the `int` typename
 	// - `SliceType.Validator("[]varchar", avail...)` validates a slice containing
-	//   values that are valid to the `VarcharType`
+	//   values that are valid to the `varchar` type
 	//
 	// and so on.. this works for maps, structs, etc
 	Validator(typename string, avail ...Type) ValidateFunc


### PR DESCRIPTION
- add an error to `RespondWith()` when the responder is nil
- replace `Output(typename string, type reflect.Type)` with `Output(string, interface{})` and process `reflect.TypeOf()` internally
  - it avoids to force users to import the reflect package