### PR TITLE
feature: remove bind shortcuts: get, put, post, delete

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -172,26 +172,6 @@ func (b *Builder) Bind(method, path string, fn interface{}) error {
 	return nil
 }
 
-// Get is equivalent to Bind(http.MethodGet)
-func (b *Builder) Get(path string, fn interface{}) error {
-	return b.Bind(http.MethodGet, path, fn)
-}
-
-// Post is equivalent to Bind(http.MethodPost)
-func (b *Builder) Post(path string, fn interface{}) error {
-	return b.Bind(http.MethodPost, path, fn)
-}
-
-// Put is equivalent to Bind(http.MethodPut)
-func (b *Builder) Put(path string, fn interface{}) error {
-	return b.Bind(http.MethodPut, path, fn)
-}
-
-// Delete is equivalent to Bind(http.MethodDelete)
-func (b *Builder) Delete(path string, fn interface{}) error {
-	return b.Bind(http.MethodDelete, path, fn)
-}
-
 // Build a fully-featured HTTP server
 func (b Builder) Build() (http.Handler, error) {
 	if b.maxURISize == 0 {

--- a/builder_test.go
+++ b/builder_test.go
@@ -174,66 +174,6 @@ func TestBindInvalidHandler(t *testing.T) {
 	}
 }
 
-func TestBindMethods(t *testing.T) {
-	t.Parallel()
-
-	builder := &Builder{}
-	err := builder.Setup(strings.NewReader(`[
-		{
-			"method": "GET",
-			"path": "/path",
-			"scope": [[]],
-			"info": "info",
-			"in": {},
-			"out": {}
-		},
-		{
-			"method": "POST",
-			"path": "/path",
-			"scope": [[]],
-			"info": "info",
-			"in": {},
-			"out": {}
-		},
-		{
-			"method": "PUT",
-			"path": "/path",
-			"scope": [[]],
-			"info": "info",
-			"in": {},
-			"out": {}
-		},
-		{
-			"method": "DELETE",
-			"path": "/path",
-			"scope": [[]],
-			"info": "info",
-			"in": {},
-			"out": {}
-		}
-	]`))
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	err = builder.Get("/path", func(context.Context) (*struct{}, error) { return nil, nil })
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-	err = builder.Post("/path", func(context.Context) (*struct{}, error) { return nil, nil })
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-	err = builder.Put("/path", func(context.Context) (*struct{}, error) { return nil, nil })
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-	err = builder.Delete("/path", func(context.Context) (*struct{}, error) { return nil, nil })
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-}
-
 func TestUnhandledService(t *testing.T) {
 	t.Parallel()
 
@@ -260,7 +200,7 @@ func TestUnhandledService(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	err = builder.Get("/path", func(context.Context) (*struct{}, error) { return nil, nil })
+	err = builder.Bind(http.MethodGet, "/path", func(context.Context) (*struct{}, error) { return nil, nil })
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}


### PR DESCRIPTION
These shortcut methods had to be removed as they just add overhead to the api. Moreover, it would be nice to support other (even custom) http methods; these were in the way.