### PR TITLE
chore: refactor tests, improve coverage, reduce cyclomatic complexity

### DIFF
--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -59,7 +59,7 @@ func TestError_ErrorStatusFormat(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.err.Error() != tc.reason {
-				t.Fatalf("expected Error() = '%s', got '%s'", tc.reason, tc.err.Error())
+				t.Fatalf("expected Error() = %q, got %q", tc.reason, tc.err.Error())
 			}
 			if tc.err.Status() != tc.status {
 				t.Fatalf("expected Status() = %d, got %d", tc.status, tc.err.Status())
@@ -129,7 +129,7 @@ func TestError_CustomError(t *testing.T) {
 		t.Fatalf("unexpected status %d ; expected %d", err.Status(), status)
 	}
 	if err.Error() != reason {
-		t.Fatalf("unexpected reason '%s' ; expected '%s'", err.Error(), reason)
+		t.Fatalf("unexpected reason %q ; expected %q", err.Error(), reason)
 	}
 
 }

--- a/builder.go
+++ b/builder.go
@@ -155,12 +155,12 @@ func (b *Builder) Bind(method, path string, fn interface{}) error {
 	}
 
 	if service == nil {
-		return fmt.Errorf("%s '%s': %w", method, path, errUnknownService)
+		return fmt.Errorf("%s %q: %w", method, path, errUnknownService)
 	}
 
 	var dyn, err = dynfunc.Build(fn, *service)
 	if err != nil {
-		return fmt.Errorf("%s '%s' handler: %w", method, path, err)
+		return fmt.Errorf("%s %q handler: %w", method, path, err)
 	}
 
 	b.handlers = append(b.handlers, &serviceHandler{
@@ -194,7 +194,7 @@ func (b Builder) Build() (http.Handler, error) {
 			}
 		}
 		if !isHandled {
-			return nil, fmt.Errorf("%s '%s': %w", service.Method, service.Pattern, errMissingHandler)
+			return nil, fmt.Errorf("%s %q: %w", service.Method, service.Pattern, errMissingHandler)
 		}
 	}
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -213,36 +213,36 @@ func TestUnhandledService(t *testing.T) {
 func TestBind(t *testing.T) {
 	t.Parallel()
 
-	tcases := []struct {
-		Name          string
-		Config        string
-		HandlerMethod string
-		HandlerPath   string
-		HandlerFn     interface{} // not bound if nil
-		BindErr       error
-		BuildErr      error
+	tt := []struct {
+		name          string
+		conf          string
+		handlerMethod string
+		handlerPath   string
+		handler       interface{} // not bound if nil
+		bindErr       error
+		buildErr      error
 	}{
 		{
-			Name:          "none required none provided",
-			Config:        "[]",
-			HandlerMethod: "",
-			HandlerPath:   "",
-			HandlerFn:     nil,
-			BindErr:       nil,
-			BuildErr:      nil,
+			name:          "none required none provided",
+			conf:          "[]",
+			handlerMethod: "",
+			handlerPath:   "",
+			handler:       nil,
+			bindErr:       nil,
+			buildErr:      nil,
 		},
 		{
-			Name:          "none required 1 provided",
-			Config:        "[]",
-			HandlerMethod: "",
-			HandlerPath:   "",
-			HandlerFn:     func(context.Context) (*struct{}, error) { return nil, nil },
-			BindErr:       errUnknownService,
-			BuildErr:      nil,
+			name:          "none required 1 provided",
+			conf:          "[]",
+			handlerMethod: "",
+			handlerPath:   "",
+			handler:       func(context.Context) (*struct{}, error) { return nil, nil },
+			bindErr:       errUnknownService,
+			buildErr:      nil,
 		},
 		{
-			Name: "1 required none provided",
-			Config: `[
+			name: "1 required none provided",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -252,15 +252,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: "",
-			HandlerPath:   "",
-			HandlerFn:     nil,
-			BindErr:       nil,
-			BuildErr:      errMissingHandler,
+			handlerMethod: "",
+			handlerPath:   "",
+			handler:       nil,
+			bindErr:       nil,
+			buildErr:      errMissingHandler,
 		},
 		{
-			Name: "1 required wrong method provided",
-			Config: `[
+			name: "1 required wrong method provided",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -270,15 +270,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodPost,
-			HandlerPath:   "/path",
-			HandlerFn:     func(context.Context) (*struct{}, error) { return nil, nil },
-			BindErr:       errUnknownService,
-			BuildErr:      errMissingHandler,
+			handlerMethod: http.MethodPost,
+			handlerPath:   "/path",
+			handler:       func(context.Context) (*struct{}, error) { return nil, nil },
+			bindErr:       errUnknownService,
+			buildErr:      errMissingHandler,
 		},
 		{
-			Name: "1 required wrong path provided",
-			Config: `[
+			name: "1 required wrong path provided",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -288,15 +288,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodGet,
-			HandlerPath:   "/paths",
-			HandlerFn:     func(context.Context) (*struct{}, error) { return nil, nil },
-			BindErr:       errUnknownService,
-			BuildErr:      errMissingHandler,
+			handlerMethod: http.MethodGet,
+			handlerPath:   "/paths",
+			handler:       func(context.Context) (*struct{}, error) { return nil, nil },
+			bindErr:       errUnknownService,
+			buildErr:      errMissingHandler,
 		},
 		{
-			Name: "1 required valid provided",
-			Config: `[
+			name: "1 required valid provided",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -306,15 +306,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodGet,
-			HandlerPath:   "/path",
-			HandlerFn:     func(context.Context) (*struct{}, error) { return nil, nil },
-			BindErr:       nil,
-			BuildErr:      nil,
+			handlerMethod: http.MethodGet,
+			handlerPath:   "/path",
+			handler:       func(context.Context) (*struct{}, error) { return nil, nil },
+			bindErr:       nil,
+			buildErr:      nil,
 		},
 		{
-			Name: "1 required with int",
-			Config: `[
+			name: "1 required with int",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -326,15 +326,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodGet,
-			HandlerPath:   "/path",
-			HandlerFn:     func(context.Context, struct{ Name int }) (*struct{}, error) { return nil, nil },
-			BindErr:       nil,
-			BuildErr:      nil,
+			handlerMethod: http.MethodGet,
+			handlerPath:   "/path",
+			handler:       func(context.Context, struct{ Name int }) (*struct{}, error) { return nil, nil },
+			bindErr:       nil,
+			buildErr:      nil,
 		},
 		{
-			Name: "1 required with uint",
-			Config: `[
+			name: "1 required with uint",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -346,15 +346,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodGet,
-			HandlerPath:   "/path",
-			HandlerFn:     func(context.Context, struct{ Name uint }) (*struct{}, error) { return nil, nil },
-			BindErr:       nil,
-			BuildErr:      nil,
+			handlerMethod: http.MethodGet,
+			handlerPath:   "/path",
+			handler:       func(context.Context, struct{ Name uint }) (*struct{}, error) { return nil, nil },
+			bindErr:       nil,
+			buildErr:      nil,
 		},
 		{
-			Name: "1 required with string",
-			Config: `[
+			name: "1 required with string",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -366,15 +366,15 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodGet,
-			HandlerPath:   "/path",
-			HandlerFn:     func(context.Context, struct{ Name string }) (*struct{}, error) { return nil, nil },
-			BindErr:       nil,
-			BuildErr:      nil,
+			handlerMethod: http.MethodGet,
+			handlerPath:   "/path",
+			handler:       func(context.Context, struct{ Name string }) (*struct{}, error) { return nil, nil },
+			bindErr:       nil,
+			buildErr:      nil,
 		},
 		{
-			Name: "1 required with bool",
-			Config: `[
+			name: "1 required with bool",
+			conf: `[
 				{
 					"method": "GET",
 					"path": "/path",
@@ -386,39 +386,38 @@ func TestBind(t *testing.T) {
 					"out": {}
 				}
 			]`,
-			HandlerMethod: http.MethodGet,
-			HandlerPath:   "/path",
-			HandlerFn:     func(context.Context, struct{ Name bool }) (*struct{}, error) { return nil, nil },
-			BindErr:       nil,
-			BuildErr:      nil,
+			handlerMethod: http.MethodGet,
+			handlerPath:   "/path",
+			handler:       func(context.Context, struct{ Name bool }) (*struct{}, error) { return nil, nil },
+			bindErr:       nil,
+			buildErr:      nil,
 		},
 	}
 
-	for _, tcase := range tcases {
-		t.Run(tcase.Name, func(t *testing.T) {
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			builder := &Builder{}
-
 			if err := addBuiltinTypes(builder); err != nil {
 				t.Fatalf("add built-in types: %s", err)
 			}
 
-			err := builder.Setup(strings.NewReader(tcase.Config))
+			err := builder.Setup(strings.NewReader(tc.conf))
 			if err != nil {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
 
-			if tcase.HandlerFn != nil {
-				err := builder.Bind(tcase.HandlerMethod, tcase.HandlerPath, tcase.HandlerFn)
-				if !errors.Is(err, tcase.BindErr) {
-					t.Fatalf("bind: expected <%v> got <%v>", tcase.BindErr, err)
+			if tc.handler != nil {
+				err := builder.Bind(tc.handlerMethod, tc.handlerPath, tc.handler)
+				if !errors.Is(err, tc.bindErr) {
+					t.Fatalf("invalid bind error\nactual: %v\nexpect: %v", err, tc.bindErr)
 				}
 			}
 
 			_, err = builder.Build()
-			if !errors.Is(err, tcase.BuildErr) {
-				t.Fatalf("build: expected <%v> got <%v>", tcase.BuildErr, err)
+			if !errors.Is(err, tc.buildErr) {
+				t.Fatalf("invalid build error\nactual: %v\nexpect: %v", err, tc.buildErr)
 			}
 
 		})

--- a/handler.go
+++ b/handler.go
@@ -65,7 +65,7 @@ func (s Handler) resolve(w http.ResponseWriter, r *http.Request) {
 	// Only URI arguments can be used
 	var input = reqdata.New(service)
 	if err := input.GetURI(*r); err != nil {
-		// should never fail as type validators are always checks in
+		// should never fail as type validators are always checked in
 		// s.conf.Find -> config.Service.matchPattern
 		s.respond(w, nil, enrichInputError(err))
 		return
@@ -79,9 +79,9 @@ func (s Handler) resolve(w http.ResponseWriter, r *http.Request) {
 
 	// create http handler
 	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// should not happen
 		auth := api.GetAuth(r.Context())
 		if auth == nil {
+			// should never happen
 			s.respond(w, nil, api.ErrForbidden)
 			return
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,7 +131,7 @@ func TestHandlerWith(t *testing.T) {
 	}
 	token := fmt.Sprintf("#%d#", n)
 	if !strings.Contains(response.Body.String(), token) {
-		t.Fatalf("expected '%s' to be in response <%s>", token, response.Body.String())
+		t.Fatalf("expected %q to be in response <%s>", token, response.Body.String())
 	}
 
 }
@@ -1220,7 +1220,7 @@ Content-Disposition: form-data; name="id"
 			}
 
 			if parsedError.Status != tc.errReason {
-				t.Fatalf("invalid error description '%s' ; expected '%s'", parsedError.Status, tc.errReason)
+				t.Fatalf("invalid error description %q ; expected %q", parsedError.Status, tc.errReason)
 			}
 
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,11 +146,8 @@ func checkURICollision(uriA, uriB []string, inputA, inputB map[string]*Parameter
 		// A captures B -> check type (B is A ?)
 		if aIsCapture {
 			input, exists := inputA[aPart]
-
-			// fail if no type or no validator
 			if !exists || input.Validator == nil {
-				errors = append(errors, fmt.Errorf("%w (invalid type for %s)", ErrPatternCollision, aPart))
-				continue
+				panic(fmt.Errorf("invalid validator %q", aPart))
 			}
 
 			// fail if not valid
@@ -162,11 +159,8 @@ func checkURICollision(uriA, uriB []string, inputA, inputB map[string]*Parameter
 			// B captures A -> check type (A is B ?)
 		} else if bIsCapture {
 			input, exists := inputB[bPart]
-
-			// fail if no type or no validator
 			if !exists || input.Validator == nil {
-				errors = append(errors, fmt.Errorf("%w (invalid type for %s)", ErrPatternCollision, bPart))
-				continue
+				panic(fmt.Errorf("invalid validator %q", bPart))
 			}
 
 			// fail if not valid

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ func (s Server) validate() error {
 	for _, service := range s.Services {
 		err := service.validate(s.Input, s.Output)
 		if err != nil {
-			return fmt.Errorf("%s '%s': %w", service.Method, service.Pattern, err)
+			return fmt.Errorf("%s %q: %w", service.Method, service.Pattern, err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func (s *Server) collide() error {
 
 			err := checkURICollision(aURIParts, bURIParts, aService.Input, bService.Input)
 			if err != nil {
-				return fmt.Errorf("(%s '%s') vs (%s '%s'): %w", aService.Method, aService.Pattern, bService.Method, bService.Pattern, err)
+				return fmt.Errorf("(%s %q) vs (%s %q): %w", aService.Method, aService.Pattern, bService.Method, bService.Pattern, err)
 			}
 		}
 	}
@@ -138,7 +138,7 @@ func checkURICollision(uriA, uriB []string, inputA, inputB map[string]*Parameter
 		// no capture -> check strict equality
 		if !aIsCapture && !bIsCapture {
 			if aPart == bPart {
-				errors = append(errors, fmt.Errorf("%w (same path '%s')", ErrPatternCollision, aPart))
+				errors = append(errors, fmt.Errorf("%w (same path %q)", ErrPatternCollision, aPart))
 				continue
 			}
 		}
@@ -155,7 +155,7 @@ func checkURICollision(uriA, uriB []string, inputA, inputB map[string]*Parameter
 
 			// fail if not valid
 			if _, valid := input.Validator(bPart); valid {
-				errors = append(errors, fmt.Errorf("%w (%s captures '%s')", ErrPatternCollision, aPart, bPart))
+				errors = append(errors, fmt.Errorf("%w (%s captures %q)", ErrPatternCollision, aPart, bPart))
 				continue
 			}
 
@@ -171,7 +171,7 @@ func checkURICollision(uriA, uriB []string, inputA, inputB map[string]*Parameter
 
 			// fail if not valid
 			if _, valid := input.Validator(aPart); valid {
-				errors = append(errors, fmt.Errorf("%w (%s captures '%s')", ErrPatternCollision, bPart, aPart))
+				errors = append(errors, fmt.Errorf("%w (%s captures %q)", ErrPatternCollision, bPart, aPart))
 				continue
 			}
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -120,17 +120,17 @@ func TestLegalServiceName(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if err == nil && test.Error != nil {
-				t.Errorf("expected an error: '%s'", test.Error.Error())
+				t.Errorf("expected an error: %q", test.Error.Error())
 				t.FailNow()
 			}
 			if err != nil && test.Error == nil {
-				t.Errorf("unexpected error: '%s'", err.Error())
+				t.Errorf("unexpected error: %q", err.Error())
 				t.FailNow()
 			}
 
 			if err != nil && test.Error != nil {
 				if !errors.Is(err, test.Error) {
-					t.Errorf("expected the error '%s' (got '%s')", test.Error.Error(), err.Error())
+					t.Errorf("expected the error %q (got %q)", test.Error.Error(), err.Error())
 					t.FailNow()
 				}
 			}
@@ -175,7 +175,7 @@ func TestAvailableMethods(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if test.ValidMethod && err != nil {
-				t.Errorf("unexpected error: '%s'", err.Error())
+				t.Errorf("unexpected error: %q", err.Error())
 				t.FailNow()
 			}
 
@@ -192,7 +192,7 @@ func TestParseEmpty(t *testing.T) {
 	srv := &Server{}
 	err := srv.Parse(r)
 	if err != nil {
-		t.Errorf("unexpected error (got '%s')", err)
+		t.Errorf("unexpected error (got %q)", err)
 		t.FailNow()
 	}
 }
@@ -249,7 +249,7 @@ func TestParseMissingMethodDescription(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if test.ValidDescription && err != nil {
-				t.Errorf("unexpected error: '%s'", err)
+				t.Errorf("unexpected error: %q", err)
 				t.FailNow()
 			}
 
@@ -278,7 +278,7 @@ func TestParamEmptyRenameNoRename(t *testing.T) {
 	srv.Input = append(srv.Input, validator.AnyType{})
 	err := srv.Parse(r)
 	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
+		t.Errorf("unexpected error: %q", err)
 		t.FailNow()
 	}
 
@@ -289,7 +289,7 @@ func TestParamEmptyRenameNoRename(t *testing.T) {
 
 	for _, param := range srv.Services[0].Input {
 		if param.Rename != "original" {
-			t.Errorf("expected the parameter 'original' not to be renamed to '%s'", param.Rename)
+			t.Errorf("expected the parameter 'original' not to be renamed to %q", param.Rename)
 			t.FailNow()
 		}
 	}
@@ -446,7 +446,7 @@ func TestOptionalParam(t *testing.T) {
 	srv.Input = append(srv.Input, validator.BoolType{})
 	err := srv.Parse(r)
 	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
+		t.Errorf("unexpected error: %q", err)
 		t.FailNow()
 	}
 
@@ -458,13 +458,13 @@ func TestOptionalParam(t *testing.T) {
 
 		if pName == "optional" || pName == "optional2" {
 			if !param.Optional {
-				t.Errorf("expected parameter '%s' to be optional", pName)
+				t.Errorf("expected parameter %q to be optional", pName)
 				t.Failed()
 			}
 		}
 		if pName == "required" || pName == "required2" {
 			if param.Optional {
-				t.Errorf("expected parameter '%s' to be required", pName)
+				t.Errorf("expected parameter %q to be required", pName)
 				t.Failed()
 			}
 		}
@@ -759,11 +759,11 @@ func TestParseParameters(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if err == nil && test.Error != nil {
-				t.Errorf("expected an error: '%s'", test.Error.Error())
+				t.Errorf("expected an error: %q", test.Error.Error())
 				t.FailNow()
 			}
 			if err != nil && test.Error == nil {
-				t.Errorf("unexpected error: '%s'", err.Error())
+				t.Errorf("unexpected error: %q", err.Error())
 				t.FailNow()
 			}
 
@@ -1012,11 +1012,11 @@ func TestServiceCollision(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Config))
 
 			if err == nil && test.Error != nil {
-				t.Errorf("expected an error: '%s'", test.Error.Error())
+				t.Errorf("expected an error: %q", test.Error.Error())
 				t.FailNow()
 			}
 			if err != nil && test.Error == nil {
-				t.Errorf("unexpected error: '%s'", err.Error())
+				t.Errorf("unexpected error: %q", err.Error())
 				t.FailNow()
 			}
 
@@ -1193,7 +1193,7 @@ func TestMatchSimple(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Config))
 
 			if err != nil {
-				t.Errorf("unexpected error: '%s'", err)
+				t.Errorf("unexpected error: %q", err)
 				t.FailNow()
 			}
 
@@ -1206,11 +1206,11 @@ func TestMatchSimple(t *testing.T) {
 
 			match := srv.Services[0].Match(req)
 			if test.Match && !match {
-				t.Errorf("expected '%s' to match", test.URL)
+				t.Errorf("expected %q to match", test.URL)
 				t.FailNow()
 			}
 			if !test.Match && match {
-				t.Errorf("expected '%s' NOT to match", test.URL)
+				t.Errorf("expected %q NOT to match", test.URL)
 				t.FailNow()
 			}
 		})
@@ -1277,7 +1277,7 @@ func TestFindPriority(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Config))
 
 			if err != nil {
-				t.Errorf("unexpected error: '%s'", err)
+				t.Errorf("unexpected error: %q", err)
 				t.FailNow()
 			}
 
@@ -1288,7 +1288,7 @@ func TestFindPriority(t *testing.T) {
 				t.FailNow()
 			}
 			if service.Description != test.MatchingDesc {
-				t.Errorf("expected description '%s', got '%s'", test.MatchingDesc, service.Description)
+				t.Errorf("expected description %q, got %q", test.MatchingDesc, service.Description)
 				t.FailNow()
 			}
 		})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -121,18 +121,15 @@ func TestLegalServiceName(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if err == nil && test.Error != nil {
-				t.Errorf("expected an error: %q", test.Error.Error())
-				t.FailNow()
+				t.Fatalf("expected an error: %q", test.Error.Error())
 			}
 			if err != nil && test.Error == nil {
-				t.Errorf("unexpected error: %q", err.Error())
-				t.FailNow()
+				t.Fatalf("unexpected error: %q", err.Error())
 			}
 
 			if err != nil && test.Error != nil {
 				if !errors.Is(err, test.Error) {
-					t.Errorf("expected the error %q (got %q)", test.Error.Error(), err.Error())
-					t.FailNow()
+					t.Fatalf("expected the error %q (got %q)", test.Error.Error(), err.Error())
 				}
 			}
 		})
@@ -176,13 +173,11 @@ func TestAvailableMethods(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if test.ValidMethod && err != nil {
-				t.Errorf("unexpected error: %q", err.Error())
-				t.FailNow()
+				t.Fatalf("unexpected error: %q", err.Error())
 			}
 
 			if !test.ValidMethod && !errors.Is(err, ErrUnknownMethod) {
-				t.Errorf("expected error <%s> got <%s>", ErrUnknownMethod, err)
-				t.FailNow()
+				t.Fatalf("expected error <%s> got <%s>", ErrUnknownMethod, err)
 			}
 		})
 	}
@@ -193,8 +188,7 @@ func TestParseEmpty(t *testing.T) {
 	srv := &Server{}
 	err := srv.Parse(r)
 	if err != nil {
-		t.Errorf("unexpected error (got %q)", err)
-		t.FailNow()
+		t.Fatalf("unexpected error (got %q)", err)
 	}
 }
 func TestParseJsonError(t *testing.T) {
@@ -206,8 +200,7 @@ func TestParseJsonError(t *testing.T) {
 	srv := &Server{}
 	err := srv.Parse(r)
 	if err == nil {
-		t.Errorf("expected error")
-		t.FailNow()
+		t.Fatalf("expected error")
 	}
 }
 
@@ -250,13 +243,11 @@ func TestParseMissingMethodDescription(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if test.ValidDescription && err != nil {
-				t.Errorf("unexpected error: %q", err)
-				t.FailNow()
+				t.Fatalf("unexpected error: %q", err)
 			}
 
 			if !test.ValidDescription && !errors.Is(err, ErrMissingDescription) {
-				t.Errorf("expected error <%s> got <%s>", ErrMissingDescription, err)
-				t.FailNow()
+				t.Fatalf("expected error <%s> got <%s>", ErrMissingDescription, err)
 			}
 		})
 	}
@@ -279,19 +270,16 @@ func TestParamEmptyRenameNoRename(t *testing.T) {
 	srv.Input = append(srv.Input, validator.AnyType{})
 	err := srv.Parse(r)
 	if err != nil {
-		t.Errorf("unexpected error: %q", err)
-		t.FailNow()
+		t.Fatalf("unexpected error: %q", err)
 	}
 
 	if len(srv.Services) < 1 {
-		t.Errorf("expected a service")
-		t.FailNow()
+		t.Fatalf("expected a service")
 	}
 
 	for _, param := range srv.Services[0].Input {
 		if param.Rename != "original" {
-			t.Errorf("expected the parameter 'original' not to be renamed to %q", param.Rename)
-			t.FailNow()
+			t.Fatalf("expected the parameter 'original' not to be renamed to %q", param.Rename)
 		}
 	}
 
@@ -447,13 +435,11 @@ func TestOptionalParam(t *testing.T) {
 	srv.Input = append(srv.Input, validator.BoolType{})
 	err := srv.Parse(r)
 	if err != nil {
-		t.Errorf("unexpected error: %q", err)
-		t.FailNow()
+		t.Fatalf("unexpected error: %q", err)
 	}
 
 	if len(srv.Services) < 1 {
-		t.Errorf("expected a service")
-		t.FailNow()
+		t.Fatalf("expected a service")
 	}
 	for pName, param := range srv.Services[0].Input {
 
@@ -760,18 +746,15 @@ func TestParseParameters(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Raw))
 
 			if err == nil && test.Error != nil {
-				t.Errorf("expected an error: %q", test.Error.Error())
-				t.FailNow()
+				t.Fatalf("expected an error: %q", test.Error.Error())
 			}
 			if err != nil && test.Error == nil {
-				t.Errorf("unexpected error: %q", err.Error())
-				t.FailNow()
+				t.Fatalf("unexpected error: %q", err.Error())
 			}
 
 			if err != nil && test.Error != nil {
 				if !errors.Is(err, test.Error) {
-					t.Errorf("expected the error <%s> got <%s>", test.Error, err)
-					t.FailNow()
+					t.Fatalf("expected the error <%s> got <%s>", test.Error, err)
 				}
 			}
 		})
@@ -1116,25 +1099,21 @@ func TestMatchSimple(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Config))
 
 			if err != nil {
-				t.Errorf("unexpected error: %q", err)
-				t.FailNow()
+				t.Fatalf("unexpected error: %q", err)
 			}
 
 			if len(srv.Services) != 1 {
-				t.Errorf("expected to have 1 service, got %d", len(srv.Services))
-				t.FailNow()
+				t.Fatalf("expected to have 1 service, got %d", len(srv.Services))
 			}
 
 			req := httptest.NewRequest(http.MethodGet, test.URL, nil)
 
 			match := srv.Services[0].Match(req)
 			if test.Match && !match {
-				t.Errorf("expected %q to match", test.URL)
-				t.FailNow()
+				t.Fatalf("expected %q to match", test.URL)
 			}
 			if !test.Match && match {
-				t.Errorf("expected %q NOT to match", test.URL)
-				t.FailNow()
+				t.Fatalf("expected %q NOT to match", test.URL)
 			}
 		})
 	}
@@ -1200,19 +1179,12 @@ func TestFindPriority(t *testing.T) {
 			err := srv.Parse(strings.NewReader(test.Config))
 
 			if err != nil {
-				t.Errorf("unexpected error: %q", err)
-				t.FailNow()
+				t.Fatalf("unexpected error: %q", err)
 			}
 
-			req := httptest.NewRequest(http.MethodGet, test.URL, nil)
-			service := srv.Find(req)
-			if service == nil {
-				t.Errorf("expected to find a service")
-				t.FailNow()
+				t.Fatalf("expected to find a service")
 			}
-			if service.Description != test.MatchingDesc {
-				t.Errorf("expected description %q, got %q", test.MatchingDesc, service.Description)
-				t.FailNow()
+				t.Fatalf("invalid description\nactual: %q\nexpect: %q", svc.Description, tc.info)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -843,6 +843,19 @@ func TestServiceCollision(t *testing.T) {
 		},
 		{
 			`[
+				{ "method": "GET", "path": "/a/{c}",
+					"info": "info", "in": {
+						"{c}": { "info":"info", "type": "string", "name": "c" }
+					}
+				},
+				{ "method": "GET", "path": "/a/b",
+					"info": "info", "in": {}
+				}
+			]`,
+			ErrPatternCollision,
+		},
+		{
+			`[
 				{ "method": "GET", "path": "/a/b",
 					"info": "info", "in": {}
 				},

--- a/internal/config/parameter.go
+++ b/internal/config/parameter.go
@@ -11,11 +11,11 @@ type Parameter struct {
 	Description string `json:"info"`
 	Type        string `json:"type"`
 	Rename      string `json:"name,omitempty"`
-	Optional    bool
+	Optional    bool   `json:"-"`
 	// GoType is the type the Validator will cast into
-	GoType reflect.Type
+	GoType reflect.Type `json:"-"`
 	// Validator is inferred from the "type" property
-	Validator validator.ValidateFunc
+	Validator validator.ValidateFunc `json:"-"`
 }
 
 func (param *Parameter) validate(validators ...validator.Type) error {

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -158,7 +158,7 @@ func (svc *Service) checkMethod() error {
 // example, input parameters with names `{b}` and `{d}` are expected.
 //
 // This methods sets up the service state with adding capture params that are
-// expected; checkInputs() will be able to check params agains pattern captures.
+// expected; checkInputs() will be able to check params against pattern captures
 func (svc *Service) checkPattern() error {
 	length := len(svc.Pattern)
 

--- a/internal/dynfunc/errors.go
+++ b/internal/dynfunc/errors.go
@@ -14,7 +14,7 @@ const (
 	// ErrNoServiceForHandler - no service matching this handler
 	ErrNoServiceForHandler = Err("no service found for this handler")
 
-	// errMissingHandlerArgumentParam - missing params arguments for handler
+	// ErrMissingHandlerContextArgument - missing params arguments for handler
 	ErrMissingHandlerContextArgument = Err("missing handler first argument of type context.Context")
 
 	// ErrInvalidHandlerContextArgument - missing handler output error

--- a/internal/dynfunc/signature_test.go
+++ b/internal/dynfunc/signature_test.go
@@ -219,10 +219,10 @@ func TestInputValidation(t *testing.T) {
 
 			err := s.ValidateInput(reflect.TypeOf(tc.fn))
 			if err == nil && tc.err != nil {
-				t.Fatalf("expected an error: '%s'", tc.err.Error())
+				t.Fatalf("expected an error: %q", tc.err.Error())
 			}
 			if err != nil && tc.err == nil {
-				t.Fatalf("unexpected error: '%s'", err.Error())
+				t.Fatalf("unexpected error: %q", err.Error())
 			}
 
 			if err != nil && tc.err != nil {

--- a/internal/dynfunc/signature_test.go
+++ b/internal/dynfunc/signature_test.go
@@ -218,17 +218,8 @@ func TestInputValidation(t *testing.T) {
 			}
 
 			err := s.ValidateInput(reflect.TypeOf(tc.fn))
-			if err == nil && tc.err != nil {
-				t.Fatalf("expected an error: %q", tc.err.Error())
-			}
-			if err != nil && tc.err == nil {
-				t.Fatalf("unexpected error: %q", err.Error())
-			}
-
-			if err != nil && tc.err != nil {
-				if !errors.Is(err, tc.err) {
-					t.Fatalf("expected the error <%s> got <%s>", tc.err, err)
-				}
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 		})
 	}
@@ -354,10 +345,9 @@ func TestOutputValidation(t *testing.T) {
 				Input:  nil,
 				Output: tc.output,
 			}
-
 			err := s.ValidateOutput(reflect.TypeOf(tc.fn))
 			if !errors.Is(err, tc.err) {
-				t.Fatalf("expected the error <%s> got <%s>", tc.err, err)
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 		})
 	}
@@ -548,21 +538,21 @@ func TestServiceValidation(t *testing.T) {
 			err := s.ValidateInput(reflect.TypeOf(tc.fn))
 			if err != nil {
 				if !errors.Is(err, tc.err) {
-					t.Fatalf("expected the error <%s> got <%s>", tc.err, err)
+					t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 				}
 				return
 			}
 			err = s.ValidateOutput(reflect.TypeOf(tc.fn))
 			if err != nil {
 				if !errors.Is(err, tc.err) {
-					t.Fatalf("expected the error <%s> got <%s>", tc.err, err)
+					t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 				}
 				return
 			}
 
 			// no error encountered but expected 1
 			if tc.err != nil {
-				t.Fatalf("expected an error <%v>", tc.err)
+				t.Fatalf("expected an error: %v", tc.err)
 			}
 		})
 	}

--- a/internal/reqdata/parse_parameter_test.go
+++ b/internal/reqdata/parse_parameter_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestSimpleString(t *testing.T) {
+	t.Parallel()
+
 	p := parseParameter("some-string")
 
 	cast, canCast := p.(string)
@@ -20,6 +22,8 @@ func TestSimpleString(t *testing.T) {
 }
 
 func TestSimpleFloat(t *testing.T) {
+	t.Parallel()
+
 	tcases := []float64{12.3456789, -12.3456789, 0.0000001, -0.0000001}
 
 	for i, tcase := range tcases {
@@ -39,6 +43,8 @@ func TestSimpleFloat(t *testing.T) {
 }
 
 func TestSimpleBool(t *testing.T) {
+	t.Parallel()
+
 	tcases := []bool{true, false}
 
 	for i, tcase := range tcases {
@@ -58,6 +64,8 @@ func TestSimpleBool(t *testing.T) {
 }
 
 func TestJsonStringSlice(t *testing.T) {
+	t.Parallel()
+
 	p := parseParameter(`["str1", "str2"]`)
 
 	slice, canCast := p.([]interface{})
@@ -88,6 +96,8 @@ func TestJsonStringSlice(t *testing.T) {
 }
 
 func TestStringSlice(t *testing.T) {
+	t.Parallel()
+
 	p := parseParameter([]string{"str1", "str2"})
 
 	slice, canCast := p.([]interface{})
@@ -118,6 +128,8 @@ func TestStringSlice(t *testing.T) {
 }
 
 func TestJsonPrimitiveBool(t *testing.T) {
+	t.Parallel()
+
 	tcases := []struct {
 		Raw       string
 		BoolValue bool
@@ -144,6 +156,8 @@ func TestJsonPrimitiveBool(t *testing.T) {
 }
 
 func TestJsonPrimitiveFloat(t *testing.T) {
+	t.Parallel()
+
 	tcases := []struct {
 		Raw        string
 		FloatValue float64
@@ -179,6 +193,8 @@ func TestJsonPrimitiveFloat(t *testing.T) {
 }
 
 func TestJsonBoolSlice(t *testing.T) {
+	t.Parallel()
+
 	p := parseParameter([]string{"true", "false"})
 
 	slice, canCast := p.([]interface{})
@@ -209,6 +225,8 @@ func TestJsonBoolSlice(t *testing.T) {
 }
 
 func TestBoolSlice(t *testing.T) {
+	t.Parallel()
+
 	p := parseParameter([]bool{true, false})
 
 	slice, canCast := p.([]bool)

--- a/internal/reqdata/parse_parameter_test.go
+++ b/internal/reqdata/parse_parameter_test.go
@@ -11,13 +11,11 @@ func TestSimpleString(t *testing.T) {
 
 	cast, canCast := p.(string)
 	if !canCast {
-		t.Errorf("expected parameter to be a string")
-		t.FailNow()
+		t.Fatalf("expected parameter to be a string")
 	}
 
 	if cast != "some-string" {
-		t.Errorf("expected parameter to equal 'some-string', got %q", cast)
-		t.FailNow()
+		t.Fatalf("expected parameter to equal 'some-string', got %q", cast)
 	}
 }
 
@@ -30,13 +28,11 @@ func TestSimpleFloat(t *testing.T) {
 
 			cast, canCast := p.(float64)
 			if !canCast {
-				t.Errorf("expected parameter to be a float64")
-				t.FailNow()
+				t.Fatalf("expected parameter to be a float64")
 			}
 
 			if math.Abs(cast-tcase) > 0.00000001 {
-				t.Errorf("expected parameter to equal '%f', got '%f'", tcase, cast)
-				t.FailNow()
+				t.Fatalf("expected parameter to equal '%f', got '%f'", tcase, cast)
 			}
 		})
 	}
@@ -51,13 +47,11 @@ func TestSimpleBool(t *testing.T) {
 
 			cast, canCast := p.(bool)
 			if !canCast {
-				t.Errorf("expected parameter to be a bool")
-				t.FailNow()
+				t.Fatalf("expected parameter to be a bool")
 			}
 
 			if cast != tcase {
-				t.Errorf("expected parameter to equal '%t', got '%t'", tcase, cast)
-				t.FailNow()
+				t.Fatalf("expected parameter to equal '%t', got '%t'", tcase, cast)
 			}
 		})
 	}
@@ -68,13 +62,11 @@ func TestJsonStringSlice(t *testing.T) {
 
 	slice, canCast := p.([]interface{})
 	if !canCast {
-		t.Errorf("expected parameter to be a []interface{}")
-		t.FailNow()
+		t.Fatalf("expected parameter to be a []interface{}")
 	}
 
 	if len(slice) != 2 {
-		t.Errorf("expected 2 values, got %d", len(slice))
-		t.FailNow()
+		t.Fatalf("expected 2 values, got %d", len(slice))
 	}
 
 	results := []string{"str1", "str2"}
@@ -100,13 +92,11 @@ func TestStringSlice(t *testing.T) {
 
 	slice, canCast := p.([]interface{})
 	if !canCast {
-		t.Errorf("expected parameter to be a []interface{}")
-		t.FailNow()
+		t.Fatalf("expected parameter to be a []interface{}")
 	}
 
 	if len(slice) != 2 {
-		t.Errorf("expected 2 values, got %d", len(slice))
-		t.FailNow()
+		t.Fatalf("expected 2 values, got %d", len(slice))
 	}
 
 	results := []string{"str1", "str2"}
@@ -142,13 +132,11 @@ func TestJsonPrimitiveBool(t *testing.T) {
 
 			cast, canCast := p.(bool)
 			if !canCast {
-				t.Errorf("expected parameter to be a bool")
-				t.FailNow()
+				t.Fatalf("expected parameter to be a bool")
 			}
 
 			if cast != tcase.BoolValue {
-				t.Errorf("expected a value of %t, got %t", tcase.BoolValue, cast)
-				t.FailNow()
+				t.Fatalf("expected a value of %t, got %t", tcase.BoolValue, cast)
 			}
 		})
 	}
@@ -179,13 +167,11 @@ func TestJsonPrimitiveFloat(t *testing.T) {
 
 			cast, canCast := p.(float64)
 			if !canCast {
-				t.Errorf("expected parameter to be a float64")
-				t.FailNow()
+				t.Fatalf("expected parameter to be a float64")
 			}
 
 			if math.Abs(cast-tcase.FloatValue) > 0.00001 {
-				t.Errorf("expected a value of %f, got %f", tcase.FloatValue, cast)
-				t.FailNow()
+				t.Fatalf("expected a value of %f, got %f", tcase.FloatValue, cast)
 			}
 		})
 	}
@@ -197,13 +183,11 @@ func TestJsonBoolSlice(t *testing.T) {
 
 	slice, canCast := p.([]interface{})
 	if !canCast {
-		t.Errorf("expected parameter to be a []interface{}")
-		t.FailNow()
+		t.Fatalf("expected parameter to be a []interface{}")
 	}
 
 	if len(slice) != 2 {
-		t.Errorf("expected 2 values, got %d", len(slice))
-		t.FailNow()
+		t.Fatalf("expected 2 values, got %d", len(slice))
 	}
 
 	results := []bool{true, false}
@@ -229,13 +213,11 @@ func TestBoolSlice(t *testing.T) {
 
 	slice, canCast := p.([]bool)
 	if !canCast {
-		t.Errorf("expected parameter to be a []bool")
-		t.FailNow()
+		t.Fatalf("expected parameter to be a []bool")
 	}
 
 	if len(slice) != 2 {
-		t.Errorf("expected 2 values, got %d", len(slice))
-		t.FailNow()
+		t.Fatalf("expected 2 values, got %d", len(slice))
 	}
 
 	results := []bool{true, false}

--- a/internal/reqdata/parse_parameter_test.go
+++ b/internal/reqdata/parse_parameter_test.go
@@ -16,7 +16,7 @@ func TestSimpleString(t *testing.T) {
 	}
 
 	if cast != "some-string" {
-		t.Errorf("expected parameter to equal 'some-string', got '%s'", cast)
+		t.Errorf("expected parameter to equal 'some-string', got %q", cast)
 		t.FailNow()
 	}
 }
@@ -87,7 +87,7 @@ func TestJsonStringSlice(t *testing.T) {
 			continue
 		}
 		if cast != res {
-			t.Errorf("expected first value to be '%s', got '%s'", res, cast)
+			t.Errorf("expected first value to be %q, got %q", res, cast)
 			continue
 		}
 
@@ -119,7 +119,7 @@ func TestStringSlice(t *testing.T) {
 			continue
 		}
 		if cast != res {
-			t.Errorf("expected first value to be '%s', got '%s'", res, cast)
+			t.Errorf("expected first value to be %q, got %q", res, cast)
 			continue
 		}
 

--- a/internal/reqdata/set.go
+++ b/internal/reqdata/set.go
@@ -47,9 +47,8 @@ func (i *T) GetURI(req http.Request) error {
 		}
 		value := uriparts[capture.Index]
 
-		// should not happen
 		if capture.Ref == nil {
-			return &Err{field: capture.Ref.Rename, err: ErrUnknownType}
+			panic(fmt.Errorf("unknown uri part type: %q", capture.Name))
 		}
 
 		parsed := parseParameter(value)

--- a/internal/reqdata/set_test.go
+++ b/internal/reqdata/set_test.go
@@ -156,7 +156,7 @@ func TestStoreWithUri(t *testing.T) {
 					t.Fatalf("error should be of type *Err")
 				}
 				if cast.Field() != tc.errField {
-					t.Fatalf("error field is '%s' ; expected '%s'", cast.Field(), tc.errField)
+					t.Fatalf("error field is %q ; expected %q", cast.Field(), tc.errField)
 				}
 				return
 			}
@@ -354,7 +354,7 @@ func TestExtractQuery(t *testing.T) {
 					t.Fatalf("error should be of type *Err")
 				}
 				if cast.Field() != tc.errField {
-					t.Fatalf("error field is '%s' ; expected '%s'", cast.Field(), tc.errField)
+					t.Fatalf("error field is %q ; expected %q", cast.Field(), tc.errField)
 				}
 				return
 			}
@@ -388,7 +388,7 @@ func TestExtractQuery(t *testing.T) {
 							t.Fatalf("should return a string (got '%v')", cast)
 						}
 						if values[0] != cast {
-							t.Fatalf("should return '%s' (got '%s')", values[0], cast)
+							t.Fatalf("should return %q (got %q)", values[0], cast)
 						}
 						return
 					}
@@ -405,7 +405,7 @@ func TestExtractQuery(t *testing.T) {
 
 					for vi, value := range values {
 						if value != cast[vi] {
-							t.Fatalf("should return '%s' (got '%s')", value, cast[vi])
+							t.Fatalf("should return %q (got %q)", value, cast[vi])
 						}
 					}
 				})
@@ -621,7 +621,7 @@ func TestExtractFormUrlEncoded(t *testing.T) {
 					t.Fatalf("error should be of type *Err")
 				}
 				if cast.Field() != tc.errField {
-					t.Fatalf("error field is '%s' ; expected '%s'", cast.Field(), tc.errField)
+					t.Fatalf("error field is %q ; expected %q", cast.Field(), tc.errField)
 				}
 				return
 			}
@@ -655,7 +655,7 @@ func TestExtractFormUrlEncoded(t *testing.T) {
 							t.Fatalf("should return a string (got '%v')", cast)
 						}
 						if values[0] != cast {
-							t.Fatalf("should return '%s' (got '%s')", values[0], cast)
+							t.Fatalf("should return %q (got %q)", values[0], cast)
 						}
 						return
 					}
@@ -672,7 +672,7 @@ func TestExtractFormUrlEncoded(t *testing.T) {
 
 					for vi, value := range values {
 						if value != cast[vi] {
-							t.Fatalf("should return '%s' (got '%s')", value, cast[vi])
+							t.Fatalf("should return %q (got %q)", value, cast[vi])
 						}
 					}
 				})
@@ -807,7 +807,7 @@ func TestJsonParameters(t *testing.T) {
 
 					param, isset := store.Data[key]
 					if !isset {
-						t.Fatalf("store should contain element with key '%s'", key)
+						t.Fatalf("store should contain element with key %q", key)
 						return
 					}
 
@@ -1005,7 +1005,7 @@ Content-Type: application/zip
 				t.Run(key, func(t *testing.T) {
 					param, exists := store.Data[key]
 					if !exists {
-						t.Fatalf("store should contain element with key '%s'", key)
+						t.Fatalf("store should contain element with key %q", key)
 						return
 					}
 

--- a/internal/reqdata/set_test.go
+++ b/internal/reqdata/set_test.go
@@ -87,76 +87,76 @@ func getServiceWithForm(t reflect.Type, params ...string) *config.Service {
 
 func TestStoreWithUri(t *testing.T) {
 	tt := []struct {
-		name          string
-		serviceParams []string
-		uri           string
-		err           error
-		errField      string
+		name   string
+		params []string
+		uri    string
+		err    error
+		field  string
 	}{
 		{
-			name:          "non captured uri",
-			serviceParams: []string{},
-			uri:           "/non-captured/uri",
-			err:           nil,
+			name:   "non captured uri",
+			params: []string{},
+			uri:    "/non-captured/uri",
+			err:    nil,
 		},
 		{
-			name:          "missing uri param",
-			serviceParams: []string{"missing"},
-			uri:           "/",
-			err:           ErrMissingURIParameter,
-			errField:      "missing",
+			name:   "missing uri param",
+			params: []string{"missing"},
+			uri:    "/",
+			err:    ErrMissingURIParameter,
+			field:  "missing",
 		},
 		{
-			name:          "missing uri params",
-			serviceParams: []string{"gotit", "missing"},
-			uri:           "/gotme",
-			err:           ErrMissingURIParameter,
-			errField:      "missing",
+			name:   "missing uri params",
+			params: []string{"gotit", "missing"},
+			uri:    "/gotme",
+			err:    ErrMissingURIParameter,
+			field:  "missing",
 		},
 		{
-			name:          "2 uri params",
-			serviceParams: []string{"gotit", "gotittoo"},
-			uri:           "/gotme/andme",
-			err:           nil,
+			name:   "2 uri params",
+			params: []string{"gotit", "gotittoo"},
+			uri:    "/gotme/andme",
+			err:    nil,
 		},
 		{
-			name:          "2 uri params end ignored",
-			serviceParams: []string{"gotit", "gotittoo"},
-			uri:           "/gotme/andme/ignored",
-			err:           nil,
+			name:   "2 uri params end ignored",
+			params: []string{"gotit", "gotittoo"},
+			uri:    "/gotme/andme/ignored",
+			err:    nil,
 		},
 		{
-			name:          "2 uri params middle ignored",
-			serviceParams: []string{"first", "", "second"},
-			uri:           "/gotme/ignored/gotmetoo",
-			err:           nil,
+			name:   "2 uri params middle ignored",
+			params: []string{"first", "", "second"},
+			uri:    "/gotme/ignored/gotmetoo",
+			err:    nil,
 		},
 		{
-			name:          "3 uri params last missing",
-			serviceParams: []string{"first", "", "second"},
-			uri:           "/gotme/ignored",
-			err:           ErrMissingURIParameter,
-			errField:      "second",
+			name:   "3 uri params last missing",
+			params: []string{"first", "", "second"},
+			uri:    "/gotme/ignored",
+			err:    ErrMissingURIParameter,
+			field:  "second",
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			service := getServiceWithURI(tc.serviceParams...)
+			service := getServiceWithURI(tc.params...)
 			store := New(service)
 
 			req := httptest.NewRequest(http.MethodGet, "http://host.com"+tc.uri, nil)
 			err := store.GetURI(*req)
 			if !errors.Is(err, tc.err) {
-				t.Fatalf("expected error <%v>, got <%v>", tc.err, err)
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 			if err != nil {
 				cast, ok := err.(*Err)
 				if !ok {
 					t.Fatalf("error should be of type *Err")
 				}
-				if cast.Field() != tc.errField {
-					t.Fatalf("error field is %q ; expected %q", cast.Field(), tc.errField)
+				if cast.Field() != tc.field {
+					t.Fatalf("invalid field\nactual: %q\nexpect: %q", cast.Field(), tc.field)
 				}
 				return
 			}
@@ -174,187 +174,187 @@ func TestStoreWithUri(t *testing.T) {
 func TestExtractQuery(t *testing.T) {
 
 	tt := []struct {
-		name          string
-		serviceParams []string
-		query         string
-		err           error
-		errField      string
+		name   string
+		params []string
+		query  string
+		err    error
+		field  string
 
 		paramTypes  reflect.Type
 		paramNames  []string
 		paramValues [][]string
 	}{
 		{
-			name:          "none required",
-			serviceParams: []string{},
-			query:         "",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "none required",
+			params:      []string{},
+			query:       "",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 		{
-			name:          "1 required missing",
-			serviceParams: []string{"missing"},
-			query:         "",
-			err:           ErrMissingRequiredParam,
-			errField:      "missing",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "1 required missing",
+			params:      []string{"missing"},
+			query:       "",
+			err:         ErrMissingRequiredParam,
+			field:       "missing",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 		{
-			name:          "1 required ok",
-			serviceParams: []string{"a"},
-			query:         "a",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   [][]string{{""}},
+			name:        "1 required ok",
+			params:      []string{"a"},
+			query:       "a",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "1 required 1 empty",
-			serviceParams: []string{"a"},
-			query:         "a&b",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   [][]string{{""}},
+			name:        "1 required 1 empty",
+			params:      []string{"a"},
+			query:       "a&b",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "2 required 1 missing",
-			serviceParams: []string{"a", "missing"},
-			query:         "a&b",
-			err:           ErrMissingRequiredParam,
-			errField:      "missing",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "2 required 1 missing",
+			params:      []string{"a", "missing"},
+			query:       "a&b",
+			err:         ErrMissingRequiredParam,
+			field:       "missing",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 		{
-			name:          "2 required 2 empty",
-			serviceParams: []string{"a", "b"},
-			query:         "a&b",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "b"},
-			paramValues:   [][]string{{""}, {""}},
+			name:        "2 required 2 empty",
+			params:      []string{"a", "b"},
+			query:       "a&b",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "b"},
+			paramValues: [][]string{{""}, {""}},
 		},
 		{
-			name:          "1 required empty",
-			serviceParams: []string{"a"},
-			err:           nil,
-			query:         "a=",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   [][]string{{""}},
+			name:        "1 required empty",
+			params:      []string{"a"},
+			err:         nil,
+			query:       "a=",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "2 required 1 empty",
-			serviceParams: []string{"a", "b"},
-			err:           nil,
-			query:         "a=&b=x",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "b"},
-			paramValues:   [][]string{{""}, {"x"}},
+			name:        "2 required 1 empty",
+			params:      []string{"a", "b"},
+			err:         nil,
+			query:       "a=&b=x",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "b"},
+			paramValues: [][]string{{""}, {"x"}},
 		},
 		{
-			name:          "2 required 2 ok",
-			serviceParams: []string{"a", "c"},
-			err:           nil,
-			query:         "a=b&c=d",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "c"},
-			paramValues:   [][]string{{"b"}, {"d"}},
+			name:        "2 required 2 ok",
+			params:      []string{"a", "c"},
+			err:         nil,
+			query:       "a=b&c=d",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "c"},
+			paramValues: [][]string{{"b"}, {"d"}},
 		},
 		{
-			name:          "2 required 1 is slice",
-			serviceParams: []string{"a", "c"},
-			err:           ErrInvalidType,
-			errField:      "a",
-			query:         "a=b&c=d&a=x",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "c"},
-			paramValues:   [][]string{{"b", "x"}, {"d"}},
+			name:        "2 required 1 is slice",
+			params:      []string{"a", "c"},
+			err:         ErrInvalidType,
+			field:       "a",
+			query:       "a=b&c=d&a=x",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "c"},
+			paramValues: [][]string{{"b", "x"}, {"d"}},
 		},
 
 		// expect a slice
 		{
-			name:          "expect slice got empty",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=",
-			paramTypes:    reflect.TypeOf([]string{}),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{""}},
+			name:        "expect slice got empty",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=",
+			paramTypes:  reflect.TypeOf([]string{}),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "expect slice got value",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=value",
-			paramTypes:    reflect.TypeOf([]string{}),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{"value"}},
+			name:        "expect slice got value",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=value",
+			paramTypes:  reflect.TypeOf([]string{}),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{"value"}},
 		},
 		{
-			name:          "expect slice got values",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=value1&name=value2",
-			paramTypes:    reflect.TypeOf([]string{}),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{"value1", "value2"}},
+			name:        "expect slice got values",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=value1&name=value2",
+			paramTypes:  reflect.TypeOf([]string{}),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{"value1", "value2"}},
 		},
 
 		// expect string
 		{
-			name:          "expect string got empty",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{""}},
+			name:        "expect string got empty",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "expect string got value",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=value",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{"value"}},
+			name:        "expect string got value",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=value",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{"value"}},
 		},
 		{
-			name:          "expect string got values",
-			serviceParams: []string{"name"},
-			err:           ErrInvalidType,
-			errField:      "name",
-			query:         "name=value1&name=value2",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "expect string got values",
+			params:      []string{"name"},
+			err:         ErrInvalidType,
+			field:       "name",
+			query:       "name=value1&name=value2",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 
-			store := New(getServiceWithQuery(tc.paramTypes, tc.serviceParams...))
+			store := New(getServiceWithQuery(tc.paramTypes, tc.params...))
 
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://host.com?%s", tc.query), nil)
 			err := store.GetQuery(*req)
 			if !errors.Is(err, tc.err) {
-				t.Fatalf("expected error <%v>, got <%v>", tc.err, err)
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 			if err != nil {
 				cast, ok := err.(*Err)
 				if !ok {
 					t.Fatalf("error should be of type *Err")
 				}
-				if cast.Field() != tc.errField {
-					t.Fatalf("error field is %q ; expected %q", cast.Field(), tc.errField)
+				if cast.Field() != tc.field {
+					t.Fatalf("invalid field\nactual: %v\nexpect: %v", cast.Field(), tc.field)
 				}
 				return
 			}
@@ -439,167 +439,167 @@ func TestStoreWithUrlEncodedFormParseError(t *testing.T) {
 }
 func TestExtractFormUrlEncoded(t *testing.T) {
 	tt := []struct {
-		name          string
-		serviceParams []string
-		query         string
-		err           error
-		errField      string
+		name   string
+		params []string
+		query  string
+		err    error
+		field  string
 
 		paramTypes  reflect.Type
 		paramNames  []string
 		paramValues [][]string
 	}{
 		{
-			name:          "none required",
-			serviceParams: []string{},
-			query:         "",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "none required",
+			params:      []string{},
+			query:       "",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 		{
-			name:          "1 required missing",
-			serviceParams: []string{"missing"},
-			query:         "",
-			err:           ErrMissingRequiredParam,
-			errField:      "missing",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "1 required missing",
+			params:      []string{"missing"},
+			query:       "",
+			err:         ErrMissingRequiredParam,
+			field:       "missing",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 		{
-			name:          "1 required ok",
-			serviceParams: []string{"a"},
-			query:         "a",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   [][]string{{""}},
+			name:        "1 required ok",
+			params:      []string{"a"},
+			query:       "a",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "1 required 1 empty",
-			serviceParams: []string{"a"},
-			query:         "a&b",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   [][]string{{""}},
+			name:        "1 required 1 empty",
+			params:      []string{"a"},
+			query:       "a&b",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "2 required 1 missing",
-			serviceParams: []string{"a", "missing"},
-			query:         "a&b",
-			err:           ErrMissingRequiredParam,
-			errField:      "missing",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "2 required 1 missing",
+			params:      []string{"a", "missing"},
+			query:       "a&b",
+			err:         ErrMissingRequiredParam,
+			field:       "missing",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 		{
-			name:          "2 required 2 empty",
-			serviceParams: []string{"a", "b"},
-			query:         "a&b",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "b"},
-			paramValues:   [][]string{{""}, {""}},
+			name:        "2 required 2 empty",
+			params:      []string{"a", "b"},
+			query:       "a&b",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "b"},
+			paramValues: [][]string{{""}, {""}},
 		},
 		{
-			name:          "1 required empty",
-			serviceParams: []string{"a"},
-			err:           nil,
-			query:         "a=",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   [][]string{{""}},
+			name:        "1 required empty",
+			params:      []string{"a"},
+			err:         nil,
+			query:       "a=",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "2 required 1 empty",
-			serviceParams: []string{"a", "b"},
-			err:           nil,
-			query:         "a=&b=x",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "b"},
-			paramValues:   [][]string{{""}, {"x"}},
+			name:        "2 required 1 empty",
+			params:      []string{"a", "b"},
+			err:         nil,
+			query:       "a=&b=x",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "b"},
+			paramValues: [][]string{{""}, {"x"}},
 		},
 		{
-			name:          "2 required 2 ok",
-			serviceParams: []string{"a", "c"},
-			err:           nil,
-			query:         "a=b&c=d",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "c"},
-			paramValues:   [][]string{{"b"}, {"d"}},
+			name:        "2 required 2 ok",
+			params:      []string{"a", "c"},
+			err:         nil,
+			query:       "a=b&c=d",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "c"},
+			paramValues: [][]string{{"b"}, {"d"}},
 		},
 		{
-			name:          "2 required 1 is slice",
-			serviceParams: []string{"a", "c"},
-			err:           ErrInvalidType,
-			errField:      "a",
-			query:         "a=b&c=d&a=x",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "c"},
-			paramValues:   [][]string{{"b", "x"}, {"d"}},
+			name:        "2 required 1 is slice",
+			params:      []string{"a", "c"},
+			err:         ErrInvalidType,
+			field:       "a",
+			query:       "a=b&c=d&a=x",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "c"},
+			paramValues: [][]string{{"b", "x"}, {"d"}},
 		},
 
 		// expect a slice
 		{
-			name:          "expect slice got empty",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=",
-			paramTypes:    reflect.TypeOf([]string{}),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{""}},
+			name:        "expect slice got empty",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=",
+			paramTypes:  reflect.TypeOf([]string{}),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "expect slice got value",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=value",
-			paramTypes:    reflect.TypeOf([]string{}),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{"value"}},
+			name:        "expect slice got value",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=value",
+			paramTypes:  reflect.TypeOf([]string{}),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{"value"}},
 		},
 		{
-			name:          "expect slice got values",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=value1&name=value2",
-			paramTypes:    reflect.TypeOf([]string{}),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{"value1", "value2"}},
+			name:        "expect slice got values",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=value1&name=value2",
+			paramTypes:  reflect.TypeOf([]string{}),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{"value1", "value2"}},
 		},
 
 		// expect string
 		{
-			name:          "expect string got empty",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{""}},
+			name:        "expect string got empty",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{""}},
 		},
 		{
-			name:          "expect string got value",
-			serviceParams: []string{"name"},
-			err:           nil,
-			query:         "name=value",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"name"},
-			paramValues:   [][]string{{"value"}},
+			name:        "expect string got value",
+			params:      []string{"name"},
+			err:         nil,
+			query:       "name=value",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"name"},
+			paramValues: [][]string{{"value"}},
 		},
 		{
-			name:          "expect string got values",
-			serviceParams: []string{"name"},
-			err:           ErrInvalidType,
-			errField:      "name",
-			query:         "name=value1&name=value2",
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    nil,
-			paramValues:   nil,
+			name:        "expect string got values",
+			params:      []string{"name"},
+			err:         ErrInvalidType,
+			field:       "name",
+			query:       "name=value1&name=value2",
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  nil,
+			paramValues: nil,
 		},
 	}
 
@@ -610,18 +610,18 @@ func TestExtractFormUrlEncoded(t *testing.T) {
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			defer req.Body.Close()
 
-			store := New(getServiceWithForm(tc.paramTypes, tc.serviceParams...))
+			store := New(getServiceWithForm(tc.paramTypes, tc.params...))
 			err := store.GetForm(*req)
 			if !errors.Is(err, tc.err) {
-				t.Fatalf("expected error <%v>, got <%v>", tc.err, err)
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 			if err != nil {
 				cast, ok := err.(*Err)
 				if !ok {
 					t.Fatalf("error should be of type *Err")
 				}
-				if cast.Field() != tc.errField {
-					t.Fatalf("error field is %q ; expected %q", cast.Field(), tc.errField)
+				if cast.Field() != tc.field {
+					t.Fatalf("invalid field\nactual: %v\nexpect: %v", cast.Field(), tc.field)
 				}
 				return
 			}
@@ -685,10 +685,10 @@ func TestExtractFormUrlEncoded(t *testing.T) {
 
 func TestJsonParameters(t *testing.T) {
 	tt := []struct {
-		name          string
-		serviceParams []string
-		raw           string
-		err           error
+		name   string
+		params []string
+		raw    string
+		err    error
 
 		paramTypes  reflect.Type
 		paramNames  []string
@@ -696,77 +696,77 @@ func TestJsonParameters(t *testing.T) {
 	}{
 		// no need to fully check json because it is parsed with the standard library
 		{
-			name:          "empty body",
-			serviceParams: []string{},
-			raw:           "",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{},
-			paramValues:   []interface{}{},
+			name:        "empty body",
+			params:      []string{},
+			raw:         "",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{},
+			paramValues: []interface{}{},
 		},
 		{
-			name:          "empty json",
-			serviceParams: []string{},
-			raw:           "{}",
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{},
-			paramValues:   []interface{}{},
+			name:        "empty json",
+			params:      []string{},
+			raw:         "{}",
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{},
+			paramValues: []interface{}{},
 		},
 		{
-			name:          "1 provided none expected",
-			serviceParams: []string{},
-			raw:           `{ "a": "b" }`,
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{},
-			paramValues:   []interface{}{},
+			name:        "1 provided none expected",
+			params:      []string{},
+			raw:         `{ "a": "b" }`,
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{},
+			paramValues: []interface{}{},
 		},
 		{
-			name:          "1 required ok",
-			serviceParams: []string{"a"},
-			raw:           `{ "a": "b" }`,
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   []interface{}{"b"},
+			name:        "1 required ok",
+			params:      []string{"a"},
+			raw:         `{ "a": "b" }`,
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: []interface{}{"b"},
 		},
 		{
-			name:          "1 required 1 ignored",
-			serviceParams: []string{"a"},
-			raw:           `{ "a": "b", "ignored": "d" }`,
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   []interface{}{"b"},
+			name:        "1 required 1 ignored",
+			params:      []string{"a"},
+			raw:         `{ "a": "b", "ignored": "d" }`,
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: []interface{}{"b"},
 		},
 		{
-			name:          "2 required 2 ok",
-			serviceParams: []string{"a", "c"},
-			raw:           `{ "a": "b", "c": "d" }`,
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a", "c"},
-			paramValues:   []interface{}{"b", "d"},
+			name:        "2 required 2 ok",
+			params:      []string{"a", "c"},
+			raw:         `{ "a": "b", "c": "d" }`,
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a", "c"},
+			paramValues: []interface{}{"b", "d"},
 		},
 		{
-			name:          "1 required null",
-			serviceParams: []string{"a"},
-			raw:           `{ "a": null }`,
-			err:           nil,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{"a"},
-			paramValues:   []interface{}{nil},
+			name:        "1 required null",
+			params:      []string{"a"},
+			raw:         `{ "a": null }`,
+			err:         nil,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{"a"},
+			paramValues: []interface{}{nil},
 		},
 		// json parse error
 		{
-			name:          "invalid json",
-			serviceParams: []string{},
-			raw:           `{ "a": "b", }`,
-			err:           ErrInvalidJSON,
-			paramTypes:    reflect.TypeOf(""),
-			paramNames:    []string{},
-			paramValues:   []interface{}{},
+			name:        "invalid json",
+			params:      []string{},
+			raw:         `{ "a": "b", }`,
+			err:         ErrInvalidJSON,
+			paramTypes:  reflect.TypeOf(""),
+			paramNames:  []string{},
+			paramValues: []interface{}{},
 		},
 	}
 
@@ -776,11 +776,11 @@ func TestJsonParameters(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "http://host.com", body)
 			req.Header.Add("Content-Type", "application/json")
 			defer req.Body.Close()
-			store := New(getServiceWithForm(tc.paramTypes, tc.serviceParams...))
+			store := New(getServiceWithForm(tc.paramTypes, tc.params...))
 
 			err := store.GetForm(*req)
 			if !errors.Is(err, tc.err) {
-				t.Fatalf("expected error <%v>, got <%v>", tc.err, err)
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 			if err != nil {
 				return
@@ -836,10 +836,10 @@ func TestMultipartParameters(t *testing.T) {
 	fileContent := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 
 	tt := []struct {
-		name          string
-		serviceParams []string
-		rawMultipart  string
-		err           error
+		name         string
+		params       []string
+		rawMultipart string
+		err          error
 
 		// we must receive []byte when we send a file. In the opposite, we wait
 		// for a string when we send a literal parameter
@@ -849,16 +849,16 @@ func TestMultipartParameters(t *testing.T) {
 		paramValues []interface{}
 	}{
 		{
-			name:          "empty body",
-			serviceParams: []string{},
-			rawMultipart:  ``,
-			err:           nil,
-			paramNames:    []string{},
-			paramValues:   []interface{}{},
+			name:         "empty body",
+			params:       []string{},
+			rawMultipart: ``,
+			err:          nil,
+			paramNames:   []string{},
+			paramValues:  []interface{}{},
 		},
 		{
-			name:          "only boundary",
-			serviceParams: []string{},
+			name:   "only boundary",
+			params: []string{},
 			rawMultipart: `--xxx
 `,
 			err:         nil,
@@ -866,8 +866,8 @@ func TestMultipartParameters(t *testing.T) {
 			paramValues: []interface{}{},
 		},
 		{
-			name:          "only boundaries",
-			serviceParams: []string{},
+			name:   "only boundaries",
+			params: []string{},
 			rawMultipart: `--xxx
 --xxx--`,
 			err:         ErrInvalidMultipart,
@@ -875,8 +875,8 @@ func TestMultipartParameters(t *testing.T) {
 			paramValues: []interface{}{},
 		},
 		{
-			name:          "1 ignored part",
-			serviceParams: []string{},
+			name:   "1 ignored part",
+			params: []string{},
 			rawMultipart: `--xxx
 Content-Disposition: form-data; name="a"
 
@@ -886,8 +886,8 @@ b
 			paramValues: []interface{}{},
 		},
 		{
-			name:          "1 part",
-			serviceParams: []string{"a"},
+			name:   "1 part",
+			params: []string{"a"},
 			rawMultipart: `--xxx
 Content-Disposition: form-data; name="a"
 
@@ -897,8 +897,8 @@ b
 			paramValues: []interface{}{"b"},
 		},
 		{
-			name:          "2 parts",
-			serviceParams: []string{"a", "c"},
+			name:   "2 parts",
+			params: []string{"a", "c"},
 			rawMultipart: `--xxx
 Content-Disposition: form-data; name="a"
 
@@ -913,8 +913,8 @@ d
 			paramValues: []interface{}{"b", "d"},
 		},
 		{
-			name:          "1 part 1 ignored",
-			serviceParams: []string{"a"},
+			name:   "1 part 1 ignored",
+			params: []string{"a"},
 			rawMultipart: `--xxx
 Content-Disposition: form-data; name="a"
 
@@ -930,7 +930,7 @@ x
 		},
 		{
 			name:           "1 param 1 file",
-			serviceParams:  []string{"a", "file"},
+			params:         []string{"a", "file"},
 			lastParamBytes: true,
 			rawMultipart: fmt.Sprintf(`--xxx
 Content-Disposition: form-data; name="a"
@@ -960,8 +960,8 @@ Content-Type: application/zip
 				Form:  make(map[string]*config.Parameter),
 			}
 
-			for i, name := range tc.serviceParams {
-				isLast := (i == len(tc.serviceParams)-1)
+			for i, name := range tc.params {
+				isLast := (i == len(tc.params)-1)
 
 				gotype := reflect.TypeOf("")
 				if isLast && tc.lastParamBytes {
@@ -975,11 +975,11 @@ Content-Type: application/zip
 				service.Form[name] = service.Input[name]
 			}
 
-			store := New(getServiceWithForm(reflect.TypeOf(""), tc.serviceParams...))
+			store := New(getServiceWithForm(reflect.TypeOf(""), tc.params...))
 
 			err := store.GetForm(*req)
 			if !errors.Is(err, tc.err) {
-				t.Fatalf("expected error <%v>, got <%v>", tc.err, err)
+				t.Fatalf("invalid error\nactual: %v\nexpect: %v", err, tc.err)
 			}
 			if err != nil {
 				return


### PR DESCRIPTION
- cyclomatic complexity is under 15
- no more misspell
- no remaining go lint issue
- 100% coverage for internal/config
- refactor tests according to new standards ; replace old code and practices with cleaner ones, flatten some tests (I started the project when I did not know much about go, reviewing bad code is a good clue that I learned since then)
  - replace Errorf() followed by FailNow() with Fatalf()
  - rename tests cases to 'tt' and iterate over 'tc'
  - test case struct names are in camelCase (compared to PascalCase)
- replace printing '%s' with %q