### PR TITLE
refactor: the dynfunc package, improve coverage

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -200,7 +200,7 @@ func TestUnhandledService(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	err = builder.Bind(http.MethodGet, "/path", func(context.Context) (*struct{}, error) { return nil, nil })
+	err = builder.Bind(http.MethodGet, "/path", func(context.Context) error { return nil })
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -329,7 +329,7 @@ func TestBind(t *testing.T) {
 			]`,
 			handlerMethod: http.MethodGet,
 			handlerPath:   "/path",
-			handler:       func(context.Context, struct{ Name int }) (*struct{}, error) { return nil, nil },
+			handler:       func(context.Context, struct{ Name int }) error { return nil },
 			bindErr:       nil,
 			buildErr:      nil,
 		},
@@ -349,7 +349,7 @@ func TestBind(t *testing.T) {
 			]`,
 			handlerMethod: http.MethodGet,
 			handlerPath:   "/path",
-			handler:       func(context.Context, struct{ Name uint }) (*struct{}, error) { return nil, nil },
+			handler:       func(context.Context, struct{ Name uint }) error { return nil },
 			bindErr:       nil,
 			buildErr:      nil,
 		},
@@ -369,7 +369,7 @@ func TestBind(t *testing.T) {
 			]`,
 			handlerMethod: http.MethodGet,
 			handlerPath:   "/path",
-			handler:       func(context.Context, struct{ Name string }) (*struct{}, error) { return nil, nil },
+			handler:       func(context.Context, struct{ Name string }) error { return nil },
 			bindErr:       nil,
 			buildErr:      nil,
 		},
@@ -389,7 +389,7 @@ func TestBind(t *testing.T) {
 			]`,
 			handlerMethod: http.MethodGet,
 			handlerPath:   "/path",
-			handler:       func(context.Context, struct{ Name bool }) (*struct{}, error) { return nil, nil },
+			handler:       func(context.Context, struct{ Name bool }) error { return nil },
 			bindErr:       nil,
 			buildErr:      nil,
 		},

--- a/handler_test.go
+++ b/handler_test.go
@@ -96,7 +96,7 @@ func TestHandlerWith(t *testing.T) {
 		t.Fatalf("setup: unexpected error <%v>", err)
 	}
 
-	pathHandler := func(ctx context.Context) (*struct{}, error) {
+	pathHandler := func(ctx context.Context) error {
 		// write value from middlewares into response
 		value := ctx.Value(key)
 		if value == nil {
@@ -109,7 +109,7 @@ func TestHandlerWith(t *testing.T) {
 		// write to response
 		api.GetResponseWriter(ctx).Write([]byte(fmt.Sprintf("#%d#", cast)))
 
-		return nil, nil
+		return nil
 	}
 
 	if err := builder.Bind(http.MethodGet, "/path", pathHandler); err != nil {
@@ -262,8 +262,8 @@ func TestHandlerWithAuth(t *testing.T) {
 				t.Fatalf("setup: unexpected error <%v>", err)
 			}
 
-			pathHandler := func(ctx context.Context) (*struct{}, error) {
-				return nil, api.ErrNotImplemented
+			pathHandler := func(ctx context.Context) error {
+				return api.ErrNotImplemented
 			}
 
 			if err := builder.Bind(http.MethodGet, "/path", pathHandler); err != nil {
@@ -304,7 +304,7 @@ func TestHandlerPermissionError(t *testing.T) {
 			path:        "/path",
 			uri:         "/path",
 			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
-			handler:     func(ctx context.Context) (*struct{}, error) { return nil, api.ErrNotImplemented },
+			handler:     func(ctx context.Context) error { return api.ErrNotImplemented },
 			permissions: []string{"A"},
 			err:         api.ErrNotImplemented,
 		},
@@ -313,7 +313,7 @@ func TestHandlerPermissionError(t *testing.T) {
 			path:        "/path",
 			uri:         "/path",
 			config:      `[ { "method": "GET", "path": "/path", "scope": [["A"]], "info": "info", "in": {}, "out": {} } ]`,
-			handler:     func(ctx context.Context) (*struct{}, error) { return nil, api.ErrNotImplemented },
+			handler:     func(ctx context.Context) error { return api.ErrNotImplemented },
 			permissions: []string{},
 			err:         api.ErrForbidden,
 		},
@@ -334,8 +334,8 @@ func TestHandlerPermissionError(t *testing.T) {
 				},
 				"out": {}
 			} ]`,
-			handler: func(ctx context.Context, in struct{ UserID uint }) (*struct{}, error) {
-				return nil, api.ErrNotImplemented
+			handler: func(ctx context.Context, in struct{ UserID uint }) error {
+				return api.ErrNotImplemented
 			},
 			permissions: []string{},
 			err:         api.ErrUnknownService,
@@ -354,8 +354,8 @@ func TestHandlerPermissionError(t *testing.T) {
 				},
 				"out": {}
 			} ]`,
-			handler: func(ctx context.Context, in struct{ UserID uint }) (*struct{}, error) {
-				return nil, api.ErrNotImplemented
+			handler: func(ctx context.Context, in struct{ UserID uint }) error {
+				return api.ErrNotImplemented
 			},
 			permissions: []string{},
 			err:         api.ErrForbidden,
@@ -375,8 +375,8 @@ func TestHandlerPermissionError(t *testing.T) {
 				},
 				"out": {}
 			} ]`,
-			handler: func(ctx context.Context, in struct{ UserID uint }) (*struct{}, error) {
-				return nil, api.ErrNotImplemented
+			handler: func(ctx context.Context, in struct{ UserID uint }) error {
+				return api.ErrNotImplemented
 			},
 			permissions: []string{},
 			err:         api.ErrForbidden,
@@ -465,7 +465,7 @@ func TestHandlerDynamicScope(t *testing.T) {
 				}
 			]`,
 			path:        "/path/{id}",
-			handler:     func(context.Context, struct{ Input1 uint }) (*struct{}, error) { return nil, nil },
+			handler:     func(context.Context, struct{ Input1 uint }) error { return nil },
 			url:         "/path/123",
 			body:        ``,
 			permissions: []string{"user[123]"},
@@ -486,7 +486,7 @@ func TestHandlerDynamicScope(t *testing.T) {
 				}
 			]`,
 			path:        "/path/{id}",
-			handler:     func(context.Context, struct{ Input1 uint }) (*struct{}, error) { return nil, nil },
+			handler:     func(context.Context, struct{ Input1 uint }) error { return nil },
 			url:         "/path/666",
 			body:        ``,
 			permissions: []string{"user[123]"},
@@ -507,7 +507,7 @@ func TestHandlerDynamicScope(t *testing.T) {
 				}
 			]`,
 			path:        "/path/{id}",
-			handler:     func(context.Context, struct{ User uint }) (*struct{}, error) { return nil, nil },
+			handler:     func(context.Context, struct{ User uint }) error { return nil },
 			url:         "/path/123",
 			body:        ``,
 			permissions: []string{"prefix.user[123].suffix"},
@@ -532,8 +532,8 @@ func TestHandlerDynamicScope(t *testing.T) {
 			handler: func(context.Context, struct {
 				Prefix uint
 				User   uint
-			}) (*struct{}, error) {
-				return nil, nil
+			}) error {
+				return nil
 			},
 			url:         "/prefix/123/user/456",
 			body:        ``,
@@ -559,8 +559,8 @@ func TestHandlerDynamicScope(t *testing.T) {
 			handler: func(context.Context, struct {
 				Prefix uint
 				User   uint
-			}) (*struct{}, error) {
-				return nil, nil
+			}) error {
+				return nil
 			},
 			url:         "/prefix/123/user/666",
 			body:        ``,
@@ -588,8 +588,8 @@ func TestHandlerDynamicScope(t *testing.T) {
 				Prefix uint
 				User   uint
 				Suffix uint
-			}) (*struct{}, error) {
-				return nil, nil
+			}) error {
+				return nil
 			},
 			url:         "/prefix/123/user/456/suffix/789",
 			body:        ``,
@@ -617,8 +617,8 @@ func TestHandlerDynamicScope(t *testing.T) {
 				Prefix uint
 				User   uint
 				Suffix uint
-			}) (*struct{}, error) {
-				return nil, nil
+			}) error {
+				return nil
 			},
 			url:         "/prefix/123/user/666/suffix/789",
 			body:        ``,

--- a/internal/dynfunc/errors.go
+++ b/internal/dynfunc/errors.go
@@ -26,6 +26,9 @@ const (
 	// ErrUnexpectedInput - input argument is not expected
 	ErrUnexpectedInput = Err("unexpected input struct")
 
+	// ErrUnexpectedOutput - output argument is not expected
+	ErrUnexpectedOutput = Err("unexpected output struct")
+
 	// ErrMissingHandlerOutputArgument - missing output for handler
 	ErrMissingHandlerOutputArgument = Err("missing handler first output argument: output struct")
 

--- a/internal/dynfunc/handler.go
+++ b/internal/dynfunc/handler.go
@@ -16,20 +16,28 @@ type Handler struct {
 	fn interface{}
 }
 
-// Build a handler from a dynamic function and checks its signature against a
-// service configuration
+// Build a dynamic handler from a generic function (interface{}). Fail when the
+// function does not match the expected service signature (input and output
+// arguments) according to the configuration.
 //
 // `fn` must have as a signature : `func(context.Context, in) (*out, api.Err)`
-//  - `in` is a struct{} containing a field for each service input (with valid reflect.Type)
-//  - `out` is a struct{} containing a field for each service output (with valid reflect.Type)
+//  - `in`  is a struct{} containing a field for each service input
+//  - `out` is a struct{} containing a field for each service output
+//
+// Struct field names must be literally the same as the "name" field from the
+// configuration, or the argument key if no "name" is provided.
+//
+// Input struct field types must match the associated validator GoType().
+// Optional input arguments must be pointers to the validator's GoType().
+// Output struct field types must match output types.
 //
 // Special cases:
-//  - it there is no input,  `in` MUST be omitted
-//  - it there is no output, `out` CAN be omitted
+//  - when no input is configured, the `in` struct MUST be dropped
+//  - when no output is configured, the `out` struct MUST be dropped
 func Build(fn interface{}, service config.Service) (*Handler, error) {
 	var (
 		h = &Handler{
-			signature: BuildSignature(service),
+			signature: FromConfig(service),
 			fn:        fn,
 		}
 		fnType = reflect.TypeOf(fn)
@@ -51,26 +59,28 @@ func Build(fn interface{}, service config.Service) (*Handler, error) {
 // Handle binds input `data` into the dynamic function and returns an output map
 func (h *Handler) Handle(ctx context.Context, data map[string]interface{}) (map[string]interface{}, error) {
 	var (
-		fnv       = reflect.ValueOf(h.fn)
-		callArgs  = make([]reflect.Value, 0)
-		hasInput  = len(h.signature.Input) > 0
-		hasOutput = len(h.signature.Output) > 0
+		vFn   = reflect.ValueOf(h.fn)
+		tFn   = reflect.TypeOf(h.fn)
+		input = make([]reflect.Value, 0)
+
+		hasInput  = len(h.signature.In) > 0
+		hasOutput = len(h.signature.Out) > 0
 	)
 
 	// bind context
-	callArgs = append(callArgs, reflect.ValueOf(ctx))
+	input = append(input, reflect.ValueOf(ctx))
 
 	// bind input arguments
 	if hasInput {
 		// create zero value struct
 		var (
-			callStructPtr = reflect.New(fnv.Type().In(1))
-			callStruct    = callStructPtr.Elem()
+			inStructPtr = reflect.New(tFn.In(1))
+			inStruct    = inStructPtr.Elem()
 		)
 
 		// set each field
-		for name := range h.signature.Input {
-			field := callStruct.FieldByName(name)
+		for name := range h.signature.In {
+			field := inStruct.FieldByName(name)
 			if !field.CanSet() {
 				panic(fmt.Errorf("cannot set field %q", name))
 			}
@@ -81,34 +91,35 @@ func (h *Handler) Handle(ctx context.Context, data map[string]interface{}) (map[
 				continue
 			}
 
-			var refvalue = reflect.ValueOf(value)
+			vValue := reflect.ValueOf(value)
+			tValue := reflect.TypeOf(value)
 
-			// T to pointer of T
+			// convert T to pointer of T
 			if field.Kind() == reflect.Ptr {
-				var ptrType = field.Type().Elem()
-
-				if !refvalue.Type().ConvertibleTo(ptrType) {
-					panic(fmt.Errorf("cannot convert %v into *%v", refvalue.Type(), ptrType))
+				var tPtr = field.Type().Elem()
+				if !tValue.ConvertibleTo(tPtr) {
+					panic(fmt.Errorf("cannot convert %v into *%v", tValue, tPtr))
 				}
 
-				ptr := reflect.New(ptrType)
-				ptr.Elem().Set(reflect.ValueOf(value).Convert(ptrType))
-
+				ptr := reflect.New(tPtr)
+				ptr.Elem().Set(vValue.Convert(tPtr))
 				field.Set(ptr)
 				continue
 			}
 
-			if !reflect.ValueOf(value).Type().ConvertibleTo(field.Type()) {
-				panic(fmt.Errorf("cannot convert %v into %v", reflect.ValueOf(value).Type(), field.Type()))
+			// not convertible
+			if !tValue.ConvertibleTo(field.Type()) {
+				panic(fmt.Errorf("cannot convert %v into %v", tValue, field.Type()))
 			}
 
-			field.Set(refvalue.Convert(field.Type()))
+			// non-pointer values
+			field.Set(vValue.Convert(field.Type()))
 		}
-		callArgs = append(callArgs, callStruct)
+		input = append(input, inStruct)
 	}
 
 	// call the handler
-	output := fnv.Call(callArgs)
+	output := vFn.Call(input)
 
 	var err error
 	if !output[len(output)-1].IsNil() {
@@ -122,13 +133,10 @@ func (h *Handler) Handle(ctx context.Context, data map[string]interface{}) (map[
 	}
 
 	// extract struct from pointer
-	returnStruct := output[0].Elem()
-
-	for name := range h.signature.Output {
-		field := returnStruct.FieldByName(name)
+	outStruct := output[0].Elem()
+	for name := range h.signature.Out {
+		field := outStruct.FieldByName(name)
 		outdata[name] = field.Interface()
 	}
-
-	// extract error
 	return outdata, err
 }

--- a/internal/dynfunc/handler_test.go
+++ b/internal/dynfunc/handler_test.go
@@ -14,20 +14,20 @@ type testsignature Signature
 
 // builds a mock service with provided arguments as Input and matched as Output
 func (s *testsignature) withArgs(dtypes ...reflect.Type) *testsignature {
-	if s.Input == nil {
-		s.Input = make(map[string]reflect.Type)
+	if s.In == nil {
+		s.In = make(map[string]reflect.Type)
 	}
-	if s.Output == nil {
-		s.Output = make(map[string]reflect.Type)
+	if s.Out == nil {
+		s.Out = make(map[string]reflect.Type)
 	}
 
 	for i, dtype := range dtypes {
 		name := fmt.Sprintf("P%d", i+1)
-		s.Input[name] = dtype
+		s.In[name] = dtype
 		if dtype.Kind() == reflect.Ptr {
-			s.Output[name] = dtype.Elem()
+			s.Out[name] = dtype.Elem()
 		} else {
-			s.Output[name] = dtype
+			s.Out[name] = dtype
 		}
 	}
 	return s
@@ -143,7 +143,7 @@ func TestInput(t *testing.T) {
 			t.Parallel()
 
 			var handler = &Handler{
-				signature: &Signature{Input: tc.spec.Input, Output: tc.spec.Output},
+				signature: &Signature{In: tc.spec.In, Out: tc.spec.Out},
 				fn:        tc.fn,
 			}
 

--- a/internal/dynfunc/signature.go
+++ b/internal/dynfunc/signature.go
@@ -9,19 +9,18 @@ import (
 	"github.com/xdrm-io/aicra/internal/config"
 )
 
-// Signature represents input/output arguments for service from the aicra configuration
+// Signature represents input and output arguments for a specific service of the
+// aicra configuration
 type Signature struct {
-	// Input arguments of the service
-	Input map[string]reflect.Type
-	// Output arguments of the service
-	Output map[string]reflect.Type
+	In  map[string]reflect.Type
+	Out map[string]reflect.Type
 }
 
-// BuildSignature builds a signature for a service configuration
-func BuildSignature(service config.Service) *Signature {
+// FromConfig builds the handler signature type from a service's configuration
+func FromConfig(service config.Service) *Signature {
 	s := &Signature{
-		Input:  make(map[string]reflect.Type),
-		Output: make(map[string]reflect.Type),
+		In:  make(map[string]reflect.Type),
+		Out: make(map[string]reflect.Type),
 	}
 
 	for _, param := range service.Input {
@@ -30,129 +29,128 @@ func BuildSignature(service config.Service) *Signature {
 		}
 		// make a pointer if optional
 		if param.Optional {
-			s.Input[param.Rename] = reflect.PtrTo(param.GoType)
+			s.In[param.Rename] = reflect.PtrTo(param.GoType)
 			continue
 		}
-		s.Input[param.Rename] = param.GoType
+		s.In[param.Rename] = param.GoType
 	}
 
 	for _, param := range service.Output {
 		if len(param.Rename) < 1 {
 			continue
 		}
-		s.Output[param.Rename] = param.GoType
+		s.Out[param.Rename] = param.GoType
 	}
-
 	return s
 }
 
-// ValidateInput validates a handler's input arguments against the service signature
-func (s *Signature) ValidateInput(handlerType reflect.Type) error {
-	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+// ValidateInput arguments of a handler against the signature
+func (s *Signature) ValidateInput(tHandler reflect.Type) error {
+	tContext := reflect.TypeOf((*context.Context)(nil)).Elem()
 
 	// context.Context first argument missing/invalid
-	if handlerType.NumIn() < 1 {
+	if tHandler.NumIn() < 1 {
 		return ErrMissingHandlerContextArgument
 	}
-	firstArgType := handlerType.In(0)
-	if !firstArgType.Implements(ctxType) {
+	tFirst := tHandler.In(0)
+	if !tFirst.Implements(tContext) {
 		return ErrInvalidHandlerContextArgument
 	}
 
 	// no input required
-	if len(s.Input) == 0 {
+	if len(s.In) == 0 {
 		// fail when input struct is still provided
-		if handlerType.NumIn() > 1 {
+		if tHandler.NumIn() > 1 {
 			return ErrUnexpectedInput
 		}
 		return nil
 	}
 
 	// too much arguments
-	if handlerType.NumIn() != 2 {
+	if tHandler.NumIn() != 2 {
 		return ErrMissingHandlerInputArgument
 	}
 
 	// must be a struct
-	inStruct := handlerType.In(1)
-	if inStruct.Kind() != reflect.Struct {
+	tInStruct := tHandler.In(1)
+	if tInStruct.Kind() != reflect.Struct {
 		return ErrMissingParamArgument
 	}
 
 	// check for invalid param
-	for name, ptype := range s.Input {
+	for name, tParam := range s.In {
 		if name[0] == strings.ToLower(name)[0] {
 			return fmt.Errorf("%s: %w", name, ErrUnexportedName)
 		}
 
-		field, exists := inStruct.FieldByName(name)
+		field, exists := tInStruct.FieldByName(name)
 		if !exists {
 			return fmt.Errorf("%s: %w", name, ErrMissingConfigArgument)
 		}
 
-		if !ptype.AssignableTo(field.Type) {
-			return fmt.Errorf("%s: %w (%s instead of %s)", name, ErrWrongParamTypeFromConfig, field.Type, ptype)
+		if !tParam.AssignableTo(field.Type) {
+			return fmt.Errorf("%s: %w (%s instead of %s)", name, ErrWrongParamTypeFromConfig, field.Type, tParam)
 		}
 	}
 	return nil
 }
 
-// ValidateOutput validates a handler's output arguments against the service signature
-func (s Signature) ValidateOutput(handlerType reflect.Type) error {
-	errType := reflect.TypeOf((*error)(nil)).Elem()
+// ValidateOutput arguments of a handler against the signature
+func (s Signature) ValidateOutput(tHandler reflect.Type) error {
+	tError := reflect.TypeOf((*error)(nil)).Elem()
 
-	if handlerType.NumOut() < 1 {
+	if tHandler.NumOut() < 1 {
 		return ErrMissingHandlerErrorArgument
 	}
 
-	// last output must be an error
-	lastArgType := handlerType.Out(handlerType.NumOut() - 1)
-	if !lastArgType.AssignableTo(errType) {
+	// last argument must be an error
+	tLast := tHandler.Out(tHandler.NumOut() - 1)
+	if !tLast.AssignableTo(tError) {
 		return ErrInvalidHandlerErrorArgument
 	}
 
 	// no output required
-	if len(s.Output) == 0 {
+	if len(s.Out) == 0 {
 		// fail when output struct is still provided
-		if handlerType.NumOut() > 1 {
+		if tHandler.NumOut() > 1 {
 			return ErrUnexpectedOutput
 		}
 		return nil
 	}
 
-	if handlerType.NumOut() < 2 {
+	if tHandler.NumOut() < 2 {
 		return ErrMissingHandlerOutputArgument
 	}
 
 	// fail if first output is not a pointer to struct
-	outStructPtr := handlerType.Out(0)
-	if outStructPtr.Kind() != reflect.Ptr {
+	tOutStructPtr := tHandler.Out(0)
+	if tOutStructPtr.Kind() != reflect.Ptr {
 		return ErrWrongOutputArgumentType
 	}
 
-	outStruct := outStructPtr.Elem()
-	if outStruct.Kind() != reflect.Struct {
+	tOutStruct := tOutStructPtr.Elem()
+	if tOutStruct.Kind() != reflect.Struct {
 		return ErrWrongOutputArgumentType
 	}
 
 	// fail on invalid output
-	for name, ptype := range s.Output {
+	for name, tParam := range s.Out {
 		if name[0] == strings.ToLower(name)[0] {
 			return fmt.Errorf("%s: %w", name, ErrUnexportedName)
 		}
 
-		field, exists := outStruct.FieldByName(name)
+		field, exists := tOutStruct.FieldByName(name)
 		if !exists {
 			return fmt.Errorf("%s: %w", name, ErrMissingConfigArgument)
 		}
 
 		// ignore types evalutating to nil
-		if ptype == nil {
+		if tParam == nil {
 			continue
 		}
 
-		if !field.Type.ConvertibleTo(ptype) {
-			return fmt.Errorf("%s: %w (%s instead of %s)", name, ErrWrongParamTypeFromConfig, field.Type, ptype)
+		if !field.Type.ConvertibleTo(tParam) {
+			return fmt.Errorf("%s: %w (%s instead of %s)", name, ErrWrongParamTypeFromConfig, field.Type, tParam)
 		}
 	}
 

--- a/internal/dynfunc/signature_test.go
+++ b/internal/dynfunc/signature_test.go
@@ -213,8 +213,8 @@ func TestInputValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// mock spec
 			s := Signature{
-				Input:  tc.input,
-				Output: nil,
+				In:  tc.input,
+				Out: nil,
 			}
 
 			err := s.ValidateInput(reflect.TypeOf(tc.fn))
@@ -342,8 +342,8 @@ func TestOutputValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// mock spec
 			s := Signature{
-				Input:  nil,
-				Output: tc.output,
+				In:  nil,
+				Out: tc.output,
 			}
 			err := s.ValidateOutput(reflect.TypeOf(tc.fn))
 			if !errors.Is(err, tc.err) {
@@ -539,7 +539,7 @@ func TestServiceValidation(t *testing.T) {
 				}
 			}
 
-			s := BuildSignature(service)
+			s := FromConfig(service)
 
 			err := s.ValidateInput(reflect.TypeOf(tc.fn))
 			if err != nil {

--- a/internal/dynfunc/signature_test.go
+++ b/internal/dynfunc/signature_test.go
@@ -248,7 +248,7 @@ func TestOutputValidation(t *testing.T) {
 			name:   "1 output none required",
 			output: map[string]reflect.Type{},
 			fn:     func(context.Context) (*struct{}, error) { return nil, nil },
-			err:    nil,
+			err:    ErrUnexpectedOutput,
 		},
 		{
 			name: "no output 1 required",
@@ -499,6 +499,12 @@ func TestServiceValidation(t *testing.T) {
 			},
 			fn:  func(context.Context) (*struct{ Test1 int }, error) { return nil, nil },
 			err: nil,
+		},
+		{
+			name: "unexpected out",
+			out:  []*config.Parameter{},
+			fn:   func(context.Context) (*struct{ Test1 int }, error) { return nil, nil },
+			err:  ErrUnexpectedOutput,
 		},
 		{
 			name: "optional out not ptr",


### PR DESCRIPTION
changes:
- disallow providing a handler with an output struct when it is not required
- panic on unexpected cases: function call errors with an invalid signature (the signature is always validated first)

tests:
- panics
- unexpected missing input data, skip the field left with its zero value
- build method for a single error, already mostly tested in the 'signature' package 